### PR TITLE
Fix some issues and other minor changes

### DIFF
--- a/model/aqua-sim-energy-model.cc
+++ b/model/aqua-sim-energy-model.cc
@@ -44,19 +44,19 @@ AquaSimEnergyModel::GetTypeId()
       PointerValue (),
       MakePointerAccessor (&AquaSimEnergyModel::m_device),
       MakePointerChecker<AquaSimNetDevice>())
-    .AddAttribute ("RxPower", "Rx power",
-      DoubleValue (0.75),
+    .AddAttribute ("RxPower", "Rx power: power consumption for reception (W). Default is 0.395 (1.2W).",
+      DoubleValue (0.395),
       MakeDoubleAccessor (&AquaSimEnergyModel::m_rxP),
       MakeDoubleChecker<double>())
-    .AddAttribute ("TxPower", "Tx power",
-      DoubleValue (2.0),
+    .AddAttribute ("TxPower", "Tx power: power consumption for transmission (W). Default is 0.660 (1.6W).",
+      DoubleValue (0.660),
       MakeDoubleAccessor (&AquaSimEnergyModel::m_txP),
       MakeDoubleChecker<double>())
     .AddAttribute ("InitialEnergy", "Starting energy",
       DoubleValue (10000.0),
       MakeDoubleAccessor (&AquaSimEnergyModel::SetInitialEnergy),
       MakeDoubleChecker<double>())
-    .AddAttribute ("IdlePower", "Idle power",
+    .AddAttribute ("IdlePower", "Idle power: idle power consumption (W). Default is 0.0 (0.008W)",
       DoubleValue (0.008),
       MakeDoubleAccessor (&AquaSimEnergyModel::m_idleP),
       MakeDoubleChecker<double>())
@@ -201,7 +201,7 @@ AquaSimEnergyModel::GetInitialEnergy()
 }
 
 void
-AquaSimEnergyModel::DecrIdleEnergy(double t, double idleP)
+AquaSimEnergyModel::DecrIdleEnergy(double t)
 {
   NS_LOG_FUNCTION(this << m_energy);
 
@@ -217,11 +217,11 @@ AquaSimEnergyModel::DecrIdleEnergy(double t, double idleP)
 }
 
 void
-AquaSimEnergyModel::DecrRcvEnergy(double t, double rcv)
+AquaSimEnergyModel::DecrRcvEnergy(double t)
 {
   NS_LOG_FUNCTION(this);
 
-  double dEng = t * rcv;
+  double dEng = t * m_rxP;
   if (m_energy <= dEng) {
 	  m_energy = 0.0;
 	  HandleEnergyDepletion();
@@ -233,11 +233,11 @@ AquaSimEnergyModel::DecrRcvEnergy(double t, double rcv)
 }
 
 void
-AquaSimEnergyModel::DecrTxEnergy(double t, double pT)
+AquaSimEnergyModel::DecrTxEnergy(double t)
 {
   NS_LOG_FUNCTION(this);
 
-  double dEng = t * pT;
+  double dEng = t * m_txP;
   if (m_energy <= dEng) {
 	  m_energy = 0.0;
 	  HandleEnergyDepletion();

--- a/model/aqua-sim-energy-model.h
+++ b/model/aqua-sim-energy-model.h
@@ -77,9 +77,9 @@ public:
   double GetEnergy(void);
   double GetInitialEnergy(void);
   ///To be called after an event occurs
-  void DecrIdleEnergy(double t, double idleP);
-  void DecrRcvEnergy(double t, double rcv);
-  void DecrTxEnergy(double t, double pT);
+  void DecrIdleEnergy(double t);
+  void DecrRcvEnergy(double t);
+  void DecrTxEnergy(double t);
   void DecrEnergy(double t, double decrEnergy);  //allow user to specify energy decr value
 
   /* TODO : Future work needs to incorporate total times in each state */
@@ -90,7 +90,9 @@ protected:
 private:
   double m_energy;
   double m_initialEnergy;
-  double m_rxP, m_txP, m_idleP;
+  double m_rxP,   // power consumption for reception (W)
+         m_txP,   // power consumption for transmission (W)
+         m_idleP; // idle power consumption (W)
   double m_totalEnergyConsumption;	//if energy recharging where incorporated
 
   Ptr<AquaSimNetDevice> m_device;

--- a/model/aqua-sim-header-mac.cc
+++ b/model/aqua-sim-header-mac.cc
@@ -345,11 +345,6 @@ AlohaHeader::GetTypeId()
   return tid;
 }
 
-int
-AlohaHeader::size()
-{
-  return sizeof(AquaSimAddress)*2 + 1; /*for packet_type*/
-}
 void
 AlohaHeader::SetSA(AquaSimAddress sa)
 {
@@ -447,11 +442,6 @@ FamaHeader::GetTypeId()
   return tid;
 }
 
-int
-FamaHeader::size()
-{
-  return sizeof(AquaSimAddress)*4 + 1; /*for packet_type*/
-}
 void
 FamaHeader::SetSA(AquaSimAddress sa)
 {

--- a/model/aqua-sim-header.cc
+++ b/model/aqua-sim-header.cc
@@ -41,7 +41,7 @@ NS_OBJECT_ENSURE_REGISTERED(AquaSimHeader);
 AquaSimHeader::AquaSimHeader(void) :
     m_txTime(0), m_direction(DOWN),
     m_numForwards(0), m_errorFlag(0), m_uId(-1),
-    m_timestamp(0)
+    m_size(0), m_timestamp(0)
 {
   m_nextHop = AquaSimAddress(-1);
   m_src.addr = AquaSimAddress(-1);

--- a/model/aqua-sim-mac-aloha.h
+++ b/model/aqua-sim-mac-aloha.h
@@ -105,7 +105,7 @@ protected:
   int	m_AckOn;
   double m_minBackoff;
   double m_maxBackoff;
-  double m_waitACKTime;
+  double m_waitACKTimeOffset;
   double m_maxACKRetryInterval;
 
   bool m_blocked;

--- a/model/aqua-sim-mac.cc
+++ b/model/aqua-sim-mac.cc
@@ -127,7 +127,7 @@ AquaSimMac::SendUp(Ptr<Packet> p)
   NS_ASSERT(m_device);
   AquaSimHeader ash;
   p->PeekHeader(ash);
-
+  NS_LOG_DEBUG("Me(" << this->m_address.GetAsInt() << "): Received packet from Phy : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
   if (Routing()) {
     m_macRxTrace(p);
     return Routing()->Recv(p,ash.GetDAddr(),0);
@@ -180,7 +180,7 @@ AquaSimMac::SendDown(Ptr<Packet> p, TransStatus afterTrans)
       AquaSimHeader ash;
       p->PeekHeader(ash);
       if (ash.GetTxTime().IsNegative()) ash.SetTxTime(GetTxTime(p));
-      NS_LOG_DEBUG("Sending packet to Phy : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
+      NS_LOG_DEBUG("Me(" << this->m_address.GetAsInt() << "): Sending packet to Phy : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
       Simulator::Schedule(ash.GetTxTime(), &AquaSimNetDevice::SetTransmissionStatus,m_device,afterTrans);
       //slightly awkard but for phy header Buffer
       AquaSimPacketStamp pstamp;

--- a/model/aqua-sim-mac.cc
+++ b/model/aqua-sim-mac.cc
@@ -67,11 +67,11 @@ AquaSimMac::GetTypeId(void)
     MakePointerAccessor (&AquaSimMac::m_rout),
     MakePointerChecker<AquaSimMac> ())*/
   .AddTraceSource ("RoutingTx",
-    "Trace source indicating a packet has started transmitting.",
+    "Trace source indicating a packet has been delivered to the Mac layer for transmitting.",
     MakeTraceSourceAccessor (&AquaSimMac::m_macTxTrace),
     "ns3::AquaSimMac::TxCallback")
   .AddTraceSource ("RoutingRx",
-    "Trace source indicating a packet has been received.",
+    "Trace source indicating a packet has been received and will be delivered to the Routing layer.",
     MakeTraceSourceAccessor (&AquaSimMac::m_macRxTrace),
     "ns3::AquaSimMac::RxCallback")
   ;
@@ -178,10 +178,11 @@ AquaSimMac::SendDown(Ptr<Packet> p, TransStatus afterTrans)
   else {
       m_device->SetTransmissionStatus(SEND);
       AquaSimHeader ash;
-      p->PeekHeader(ash);
+      p->RemoveHeader(ash);
       if (ash.GetTxTime().IsNegative()) ash.SetTxTime(GetTxTime(p));
       NS_LOG_DEBUG("Me(" << this->m_address.GetAsInt() << "): Sending packet to Phy : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
       Simulator::Schedule(ash.GetTxTime(), &AquaSimNetDevice::SetTransmissionStatus,m_device,afterTrans);
+      p->AddHeader(ash);
       //slightly awkard but for phy header Buffer
       AquaSimPacketStamp pstamp;
       p->AddHeader(pstamp);

--- a/model/aqua-sim-mac.cc
+++ b/model/aqua-sim-mac.cc
@@ -180,7 +180,7 @@ AquaSimMac::SendDown(Ptr<Packet> p, TransStatus afterTrans)
       AquaSimHeader ash;
       p->PeekHeader(ash);
       if (ash.GetTxTime().IsNegative()) ash.SetTxTime(GetTxTime(p));
-      NS_LOG_DEBUG("Sending packet to Phy: " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec.");
+      NS_LOG_DEBUG("Sending packet to Phy : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
       Simulator::Schedule(ash.GetTxTime(), &AquaSimNetDevice::SetTransmissionStatus,m_device,afterTrans);
       //slightly awkard but for phy header Buffer
       AquaSimPacketStamp pstamp;

--- a/model/aqua-sim-mac.cc
+++ b/model/aqua-sim-mac.cc
@@ -129,6 +129,7 @@ AquaSimMac::SendUp(Ptr<Packet> p)
   p->PeekHeader(ash);
 
   if (Routing()) {
+    m_macRxTrace(p);
     return Routing()->Recv(p,ash.GetDAddr(),0);
   }
 
@@ -136,6 +137,7 @@ AquaSimMac::SendUp(Ptr<Packet> p)
     //I am sink, no pass up implemented.
     NS_LOG_INFO("Mac:SendUp : packet at destination node:" << m_device->GetAddress() <<
       ", with end-to-end delay of " << (Simulator::Now()-ash.GetTimeStamp()).ToDouble(Time::S));
+    m_macRxTrace(p);
     return true;
   }
 
@@ -162,7 +164,7 @@ AquaSimMac::SendDown(Ptr<Packet> p, TransStatus afterTrans)
   p->Print(std::cout);
   std::cout << "\n";
   */
-
+  m_macTxTrace(p);
   if (m_device->GetTransmissionStatus() == SLEEP) {
     NS_LOG_DEBUG("SendDown::Sleeping, drop pkt");
       return false;

--- a/model/aqua-sim-mac.cc
+++ b/model/aqua-sim-mac.cc
@@ -180,6 +180,7 @@ AquaSimMac::SendDown(Ptr<Packet> p, TransStatus afterTrans)
       AquaSimHeader ash;
       p->PeekHeader(ash);
       if (ash.GetTxTime().IsNegative()) ash.SetTxTime(GetTxTime(p));
+      NS_LOG_DEBUG("Sending packet to Phy: " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec.");
       Simulator::Schedule(ash.GetTxTime(), &AquaSimNetDevice::SetTransmissionStatus,m_device,afterTrans);
       //slightly awkard but for phy header Buffer
       AquaSimPacketStamp pstamp;

--- a/model/aqua-sim-mobility-pattern.h
+++ b/model/aqua-sim-mobility-pattern.h
@@ -30,15 +30,11 @@
 #include "ns3/mobility-model.h"
 #include "ns3/timer.h"
 
-
-#ifndef PI
-#define PI 3.1415926
-#endif
-
 // Aqua Sim Mobility Pattern
 
 namespace ns3{
 
+const double PI = 3.1415926;
 /* Some redudency within these classes, compared to ns3,
 but for this port this ns2 version will suffix
 */

--- a/model/aqua-sim-net-device.cc
+++ b/model/aqua-sim-net-device.cc
@@ -561,12 +561,39 @@ AquaSimNetDevice::NeedsArp (void) const
 {
   return false;
 }
-
+/*
+if(ashSize <= pktSize)
+{
+  packet->RemoveHeader(ash);
+  uint32_t size = ash.GetSize();
+  NS_LOG_INFO("Packet size set in ash: " << size << " bytes. Packet size (bytes): " << packet->GetSize());
+  if(size <= 0)
+  {
+    ash.SetSize(packet->GetSize());
+    NS_LOG_INFO("Setting packet size to " << ash.GetSize() << " bytes (packet->GetSize() - ash.GetSerializedSize())");
+  }
+  packet->AddHeader(ash);
+}
+else
+{
+  NS_LOG_ERROR("ashSize > pktSize (" << ashSize << " < " << pktSize << ")");
+  return false;
+}
+  */
 bool
 AquaSimNetDevice::Send (Ptr< Packet > packet, const Address &dest, uint16_t protocolNumber)
 {
   NS_LOG_FUNCTION(this << packet << dest << protocolNumber);
   m_totalSentPkts++;  //debugging
+
+  AquaSimHeader ash;
+  uint32_t pktSize = packet->GetSize();
+  ash.SetSize(pktSize);
+  ash.SetSAddr(AquaSimAddress::ConvertFrom(GetAddress()));
+  ash.SetDAddr(AquaSimAddress::ConvertFrom(dest));
+  ash.SetNextHop(AquaSimAddress::GetBroadcast());
+  packet->AddHeader(ash);
+
   //Quick hack. Named Data should be NULL pointer if unused/unset.
   if (m_ndn)
   {

--- a/model/aqua-sim-net-device.cc
+++ b/model/aqua-sim-net-device.cc
@@ -678,6 +678,14 @@ AquaSimNetDevice::SetTransmissionStatus(TransStatus status)
       return;
   }
 
+  if(status == RECV)
+    NS_LOG_DEBUG("RECEIVING PACKET");
+  else if(status == NIDLE && m_transStatus == RECV)
+    NS_LOG_DEBUG("END RECEIVING PACKET");
+  else if (status == SEND)
+    NS_LOG_DEBUG("TRANSMITTING PACKET");
+  else if(status == NIDLE && m_transStatus == SEND)
+    NS_LOG_DEBUG("END TRANSMITTING PACKET");
   m_transStatus = status;
 
  if (!m_mac->SendQueueEmpty()) {

--- a/model/aqua-sim-net-device.cc
+++ b/model/aqua-sim-net-device.cc
@@ -58,7 +58,8 @@ AquaSimNetDevice::AquaSimNetDevice ()
     m_carrierId(false),
     m_ifIndex(0),
     m_mtu(64000),
-    m_totalSentPkts(0)
+    m_totalSentPkts(0),
+    m_macEnabled(true)
 {
   m_transStatus = NIDLE;
   m_configComplete = false;
@@ -561,25 +562,7 @@ AquaSimNetDevice::NeedsArp (void) const
 {
   return false;
 }
-/*
-if(ashSize <= pktSize)
-{
-  packet->RemoveHeader(ash);
-  uint32_t size = ash.GetSize();
-  NS_LOG_INFO("Packet size set in ash: " << size << " bytes. Packet size (bytes): " << packet->GetSize());
-  if(size <= 0)
-  {
-    ash.SetSize(packet->GetSize());
-    NS_LOG_INFO("Setting packet size to " << ash.GetSize() << " bytes (packet->GetSize() - ash.GetSerializedSize())");
-  }
-  packet->AddHeader(ash);
-}
-else
-{
-  NS_LOG_ERROR("ashSize > pktSize (" << ashSize << " < " << pktSize << ")");
-  return false;
-}
-  */
+
 bool
 AquaSimNetDevice::Send (Ptr< Packet > packet, const Address &dest, uint16_t protocolNumber)
 {
@@ -592,7 +575,6 @@ AquaSimNetDevice::Send (Ptr< Packet > packet, const Address &dest, uint16_t prot
   ash.SetSAddr(AquaSimAddress::ConvertFrom(GetAddress()));
   ash.SetDAddr(AquaSimAddress::ConvertFrom(dest));
   ash.SetNextHop(AquaSimAddress::GetBroadcast());
-  packet->AddHeader(ash);
 
   //Quick hack. Named Data should be NULL pointer if unused/unset.
   if (m_ndn)
@@ -602,25 +584,30 @@ AquaSimNetDevice::Send (Ptr< Packet > packet, const Address &dest, uint16_t prot
 
   if(m_routing)
     {//Note : https://www.nsnam.org/docs/release/3.24/doxygen/uan-mac-cw_8cc_source.html#l00123
-      if(m_mac)
-      {
-          //redudant
-	      //m_routing->SetMyAddr(AquaSimAddress::ConvertFrom(m_mac->GetAddress()));
-        return m_routing->Recv(packet, dest, protocolNumber);
-        //return m_routing->SendDown(packet, AquaSimAddress::ConvertFrom(dest), Seconds(0));
-      }
+
+      packet->AddHeader(ash);
+      NS_LOG_DEBUG("Me(" << AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt()  << "): Sending packet to Routing layer : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
+      return m_routing->Recv(packet, dest, protocolNumber);
     }
-  else if (m_mac)
+  else if (MacEnabled() && m_mac)
     {
+      packet->AddHeader(ash);
+      NS_LOG_DEBUG("Me(" << AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt()  << "): Sending packet to MAC layer : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
       return m_mac->TxProcess(packet);
     }
-  /*else if (m_phy)
+  else if (m_phy)
     {
-      NS_LOG_DEBUG("Phy SendDown hit");
-      return m_phy->PktTransmit(packet);
+      SetTransmissionStatus(SEND);
+      ash.SetTxTime(m_phy->CalcTxTime(pktSize));
+      NS_LOG_DEBUG("Me(" << AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt()  << "): Sending packet to Phy layer : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
+      Simulator::Schedule(ash.GetTxTime(), &AquaSimNetDevice::SetTransmissionStatus,this, NIDLE);
+      packet->AddHeader(ash);
+      //slightly awkard but for phy header Buffer
+      AquaSimPacketStamp pstamp;
+      packet->AddHeader(pstamp);
+      return m_phy->PktTransmit(packet, 0);
     }
-    */
-  else NS_LOG_WARN("Routing/Mac layers are not attached to this device. Can not send.");
+  else NS_LOG_WARN("Routing/Mac/Phy layers are not attached to this device. Can not send.");
   return false;
 }
 

--- a/model/aqua-sim-net-device.cc
+++ b/model/aqua-sim-net-device.cc
@@ -585,7 +585,7 @@ AquaSimNetDevice::Send (Ptr< Packet > packet, const Address &dest, uint16_t prot
     }
   else if (m_mac)
     {
-      return m_mac->RecvProcess(packet);
+      return m_mac->TxProcess(packet);
     }
   /*else if (m_phy)
     {

--- a/model/aqua-sim-net-device.h
+++ b/model/aqua-sim-net-device.h
@@ -177,6 +177,10 @@ public:
   bool IsAttacker(void);
 
   int TotalSentPkts() {return m_totalSentPkts;}
+
+  inline bool MacEnabled() {return m_macEnabled;}
+  inline void MacEnabled(bool value) {m_macEnabled = value;}
+
 protected:
 
   void GenerateFailure(void);
@@ -227,6 +231,8 @@ private:
   uint16_t m_mtu;
 
   int m_totalSentPkts;
+
+  bool m_macEnabled;
   //XXX remove counters
 };  // class AquaSimNetDevice
 

--- a/model/aqua-sim-phy-cmn.cc
+++ b/model/aqua-sim-phy-cmn.cc
@@ -471,7 +471,7 @@ AquaSimPhyCmn::PrevalidateIncomingPkt(Ptr<Packet> p)
       GetNetDevice()->SetTransmissionStatus(RECV);
       //SetPhyStatus(PHY_RECV);
       //finish recv packet
-      Simulator::Schedule(CalcTxTime(p->GetSize()),&AquaSimNetDevice::SetTransmissionStatus,GetNetDevice(),NIDLE);
+      Simulator::Schedule(CalcTxTime(asHeader.GetSize()),&AquaSimNetDevice::SetTransmissionStatus,GetNetDevice(),NIDLE);
   }
 
   UpdateRxEnergy(txTime, (bool)asHeader.GetErrorFlag());
@@ -539,7 +539,7 @@ AquaSimPhyCmn::PktTransmit(Ptr<Packet> p, int channelId) {
   */
   StampTxInfo(p);
 
-  Time txSendDelay = this->CalcTxTime(p->GetSize(), &m_modulationName );
+  Time txSendDelay = this->CalcTxTime(asHeader.GetSize(), &m_modulationName );
   Simulator::Schedule(txSendDelay, &AquaSimNetDevice::SetTransmissionStatus, GetNetDevice(), NIDLE);
   //Simulator::Schedule(txSendDelay, &AquaSimPhyCmn::SetPhyStatus, this, PHY_IDLE);
   /**

--- a/model/aqua-sim-phy-cmn.cc
+++ b/model/aqua-sim-phy-cmn.cc
@@ -541,8 +541,9 @@ AquaSimPhyCmn::SendPktUp(Ptr<Packet> p)
 
   switch (mach.GetDemuxPType()){
   case MacHeader::UWPTYPE_OTHER:
-    if (!GetMac()->RecvProcess(p))
-      NS_LOG_DEBUG(this << "Mac Recv error");
+    if(m_device->MacEnabled())
+      if (!GetMac()->RecvProcess(p))
+        NS_LOG_DEBUG(this << "Mac Recv error");
     break;
   case MacHeader::UWPTYPE_LOC:
     GetNetDevice()->GetMacLoc()->Recv(p);

--- a/model/aqua-sim-phy-cmn.cc
+++ b/model/aqua-sim-phy-cmn.cc
@@ -466,7 +466,6 @@ AquaSimPhyCmn::PrevalidateIncomingPkt(Ptr<Packet> p)
     */
     NS_LOG_DEBUG("PrevalidateIncomingPkt: packet error");
     asHeader.SetErrorFlag(true);
-    m_phyRxErrorTrace(p);
   }
   else {
       GetNetDevice()->SetTransmissionStatus(RECV);

--- a/model/aqua-sim-phy-cmn.h
+++ b/model/aqua-sim-phy-cmn.h
@@ -57,9 +57,6 @@ public:
   virtual ~AquaSimPhyCmn(void);
   static TypeId GetTypeId(void);
 
-  virtual void SetTxPower(double ptConsume);
-  virtual void SetRxPower(double prConsume);
-  virtual void SetIdlePower(double pIdle);
   virtual void SetSinrChecker(Ptr<AquaSimSinrChecker> sinrChecker);
   virtual void SetSignalCache(Ptr<AquaSimSignalCache> sC);
   virtual void AddModulation(Ptr<AquaSimModulation> modulation, std::string modulationName);
@@ -123,16 +120,13 @@ public:
 
 protected:
   virtual Ptr<Packet> PrevalidateIncomingPkt(Ptr<Packet> p);
-  virtual void UpdateTxEnergy(Time txTime, double pT, double pIdle);
+  virtual void UpdateTxEnergy(Time txTime);
   virtual void UpdateRxEnergy(Time txTime, bool errorFlag);
   virtual Ptr<Packet> StampTxInfo(Ptr<Packet> p);
   virtual void EnergyDeplete(void);
 
   //TODO energy model could substitute this and better define it all.
   double m_pT;		// transmitted signal power (W)
-  double m_ptConsume;	// power consumption for transmission (W)
-  double m_prConsume;	// power consumption for reception (W)
-  double m_pIdle;         // idle power consumption (W)
   double m_updateEnergyTime;	// the last time we update energy.
 
   double m_RXThresh;	// receive power threshold (W)

--- a/model/aqua-sim-phy.cc
+++ b/model/aqua-sim-phy.cc
@@ -36,6 +36,14 @@ AquaSimPhy::GetTypeId ()
 {
   static TypeId tid = TypeId("ns3::AquaSimPhy")
     .SetParent<Object>()
+    .AddTraceSource ("MacTx",
+      "Trace source indicating a packet has been delivered to the Phy layer for transmitting).",
+      MakeTraceSourceAccessor (&AquaSimPhy::m_phyTxTrace),
+      "ns3::AquaSimPhy::TxCallback")
+    .AddTraceSource ("MacRx",
+      "Trace source indicating a packet has been received and will be delivered to the Mac layer.",
+      MakeTraceSourceAccessor (&AquaSimPhy::m_phyRxTrace),
+      "ns3::AquaSimPhy::RxCallback")
   ;
   return tid;
 }

--- a/model/aqua-sim-phy.cc
+++ b/model/aqua-sim-phy.cc
@@ -74,7 +74,10 @@ AquaSimPhy::GetMac()
 Ptr<AquaSimEnergyModel>
 AquaSimPhy::EM()
 {
-  return m_device->EnergyModel();
+  if(m_device)
+    return m_device->EnergyModel();
+  else
+    return 0;
 }
 
 

--- a/model/aqua-sim-phy.cc
+++ b/model/aqua-sim-phy.cc
@@ -36,10 +36,6 @@ AquaSimPhy::GetTypeId ()
 {
   static TypeId tid = TypeId("ns3::AquaSimPhy")
     .SetParent<Object>()
-    .AddTraceSource ("RxError",
-      "Trace source indicating a packet has been received with errors.",
-      MakeTraceSourceAccessor (&AquaSimPhy::m_phyRxErrorTrace),
-      "ns3::AquaSimPhy::RxErrorCallback")
   ;
   return tid;
 }

--- a/model/aqua-sim-phy.h
+++ b/model/aqua-sim-phy.h
@@ -134,6 +134,8 @@ namespace ns3 {
 
     virtual int64_t AssignStreams (int64_t stream) = 0;
     typedef void (* TracedCallback) (Ptr<Packet> pkt, double noise);
+    typedef void (* RxCallback)(std::string path, Ptr<Packet> p);
+    typedef void (* TxCallback)(std::string path, Ptr<Packet> p);
     void NotifyTx(Ptr<Packet> packet);
     void NotifyRx(Ptr<Packet> packet);
 
@@ -156,8 +158,8 @@ namespace ns3 {
 
     //PhyStatus m_status;	// status of modem
   private:
-      ns3::TracedCallback<Ptr<Packet> > m_phyTxTrace;
-      ns3::TracedCallback<Ptr<Packet> > m_phyRxTrace;
+      ns3::TracedCallback<Ptr<const Packet> > m_phyTxTrace;
+      ns3::TracedCallback<Ptr<const Packet> > m_phyRxTrace;
   }; //AquaSimPhy class
 
 } //ns3 namespace

--- a/model/aqua-sim-phy.h
+++ b/model/aqua-sim-phy.h
@@ -72,10 +72,6 @@ namespace ns3 {
     AquaSimPhy();
     static TypeId GetTypeId();
 
-    virtual void SetTxPower(double ptConsume) = 0;
-    virtual void SetRxPower(double prConsume) = 0;
-    virtual void SetIdlePower(double pIdle) = 0;
-
     void SetNetDevice(Ptr<AquaSimNetDevice> device);
     void SetChannel(std::vector<Ptr<AquaSimChannel> > channel);
     virtual void SetSinrChecker(Ptr<AquaSimSinrChecker> sinrChecker) = 0;
@@ -143,7 +139,7 @@ namespace ns3 {
 
   protected:
     virtual Ptr<Packet> PrevalidateIncomingPkt(Ptr<Packet> p) = 0;
-    virtual void UpdateTxEnergy(Time txTime, double pT, double pIdle) = 0;
+    virtual void UpdateTxEnergy(Time txTime) = 0;
     virtual void UpdateRxEnergy(Time txTime, bool errorFlag) = 0;
     virtual Ptr<Packet> StampTxInfo(Ptr<Packet> p) = 0;
     virtual void EnergyDeplete() = 0;

--- a/model/aqua-sim-phy.h
+++ b/model/aqua-sim-phy.h
@@ -138,7 +138,6 @@ namespace ns3 {
 
     virtual int64_t AssignStreams (int64_t stream) = 0;
     typedef void (* TracedCallback) (Ptr<Packet> pkt, double noise);
-    typedef void (* RxErrorCallback) (std::string path, Ptr<const Packet> pkt);
     void NotifyTx(Ptr<Packet> packet);
     void NotifyRx(Ptr<Packet> packet);
 
@@ -159,13 +158,10 @@ namespace ns3 {
     friend class AquaSimEnergyModel;
     friend class AquaSimNetDevice;  //slightly dangerous but currrently used to remove reference cycle on disposal.
 
-    ns3::TracedCallback<Ptr<const Packet> > m_phyRxErrorTrace;
-
     //PhyStatus m_status;	// status of modem
   private:
       ns3::TracedCallback<Ptr<Packet> > m_phyTxTrace;
       ns3::TracedCallback<Ptr<Packet> > m_phyRxTrace;
-
   }; //AquaSimPhy class
 
 } //ns3 namespace

--- a/model/aqua-sim-routing-static.cc
+++ b/model/aqua-sim-routing-static.cc
@@ -109,7 +109,8 @@ AquaSimStaticRouting::Recv (Ptr<Packet> p, const Address &dest, uint16_t protoco
   NS_LOG_FUNCTION(this << p);
   AquaSimHeader ash;
   //struct hdr_ip* ih = HDR_IP(p);
-
+  p->PeekHeader(ash);
+  NS_LOG_DEBUG("Me(" << AquaSimAddress::ConvertFrom(m_device->GetAddress()).GetAsInt() << "): Received packet from MAC : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
   if (IsDeadLoop (p))
     {
       NS_LOG_INFO("Dropping packet " << p << " due to route loop");

--- a/model/aqua-sim-routing-vbf.cc
+++ b/model/aqua-sim-routing-vbf.cc
@@ -357,6 +357,24 @@ AquaSimVBF::Recv(Ptr<Packet> packet, const Address &dest, uint16_t protocolNumbe
     packet->PeekHeader(vbh);
     //ignoring forward iterator, but this can be simply changed if necessary
   }
+  std::string msg;
+  if(ash.GetDirection () == AquaSimHeader::DOWN)
+    {
+      msg = ") transmitting packet: ";
+    }
+  else
+    {
+      msg = ") receiving packet: ";
+    }
+
+  NS_LOG_INFO("Me(" << AquaSimAddress::ConvertFrom(m_device->GetAddress()).GetAsInt() << msg
+              << ash.GetSize() << " bytes ; "
+              << ash.GetTxTime().GetSeconds() << " sec. ; Dest: "
+              << ash.GetDAddr().GetAsInt()
+              << " ; Src: " << ash.GetSAddr().GetAsInt()
+              << " ; Forwards: " << ash.GetNumForwards()
+              << " ; "
+               );
   packet->AddHeader(ash);
 
 	//unsigned char msg_type =vbh.GetMessType();  //unused

--- a/model/aqua-sim-routing.cc
+++ b/model/aqua-sim-routing.cc
@@ -55,11 +55,11 @@ AquaSimRouting::GetTypeId(void)
       MakeTraceSourceAccessor (&AquaSimRouting::m_routingRxTrace),
       "ns3::AquaSimRouting::RxCallback")
     .AddTraceSource ("PacketReceived",
-      "Trace source indicating a packet has started transmitting.",
+      "Trace source indicating a packet has been delivered to the upper layer.",
       MakeTraceSourceAccessor (&AquaSimRouting::m_routingRxCbTrace),
       "ns3::AquaSimRouting::PacketReceivedCallback")
     .AddTraceSource ("PacketTransmitting",
-      "Trace source indicating a packet has started transmitting.",
+      "Trace source indicating a packet has been delivered to the lower layer.",
       MakeTraceSourceAccessor (&AquaSimRouting::m_routingTxCbTrace),
       "ns3::AquaSimRouting::PacketTransmittingCallback")
     .AddTraceSource ("TrafficPkts",
@@ -186,10 +186,8 @@ AquaSimRouting::SendDown(Ptr<Packet> p, AquaSimAddress nextHop, Time delay)
 void
 AquaSimRouting::SendPacket(Ptr<Packet> p)
 {
-  AquaSimHeader ash;
-  p->PeekHeader(ash);
-  m_routingTxCbTrace(p);
   NS_LOG_FUNCTION(this << m_mac);
+  m_routingTxCbTrace(p);
   if (!m_mac->TxProcess(p))
     NS_LOG_DEBUG(this << "Mac recv error");
 }

--- a/model/aqua-sim-routing.cc
+++ b/model/aqua-sim-routing.cc
@@ -129,7 +129,13 @@ AquaSimRouting::SendUp(Ptr<Packet> p)
   NS_LOG_FUNCTION(this << p << " : currently a dummy sendup on nodeAddr:" <<
       AquaSimAddress::ConvertFrom(m_device->GetAddress()).GetAsInt());
   m_sendUpPktCount++;
-  NS_LOG_INFO(m_sendUpPktCount);
+  NS_LOG_INFO("Me(" << AquaSimAddress::ConvertFrom(m_device->GetAddress()).GetAsInt() << "): SendUp: "
+              << ash.GetSize() << " bytes ; "
+              << ash.GetTxTime().GetSeconds() << " sec. ; Dest: "
+              << ash.GetDAddr().GetAsInt()
+              << " ; Src: " << ash.GetSAddr().GetAsInt()
+              << " ; Forwards: " << ash.GetNumForwards() << " ; Packet counter="
+              << m_sendUpPktCount);
   /*TODO this needs to be fully implemented with the multiplexer
 		  Or at least sent up for further processing
 		  ie. Sync, Localization, Application driven

--- a/model/aqua-sim-signal-cache.cc
+++ b/model/aqua-sim-signal-cache.cc
@@ -82,7 +82,7 @@ PktSubmissionTimer::AddNewSubmission(Ptr<IncomingPacket> inPkt) {
                            m_sC->m_phy->GetMac()->GetBitRate() ); */
 
   /* Need to calcuate modulation here, aka how long until entire packet is received */
-  Time transmissionDelay = m_sC->m_phy->CalcTxTime((inPkt->packet)->GetSize());
+  Time transmissionDelay = m_sC->m_phy->CalcTxTime(asHeader.GetSize());
 
   NS_LOG_FUNCTION(this << "incomingPkt:" << inPkt << "txtime:" <<
                     asHeader.GetTxTime() << " transmissionDelay:" <<

--- a/wscript
+++ b/wscript
@@ -7,7 +7,7 @@ def configure(conf):
      conf.check_nonfatal(header_name='stdint.h', define_name='HAVE_STDINT_H')
 
 def build(bld):
-    module = bld.create_ns3_module('aqua-sim-ng', ['network', 'energy', 'mobility'])
+    module = bld.create_ns3_module('aqua-sim-ng', ['network', 'energy', 'mobility', 'internet'])
     module.source = [
         'model/aqua-sim-address.cc',
         'model/aqua-sim-pt-tag.cc',


### PR DESCRIPTION
All these fixes were made months ago. I forgot to do a pull request before... 
Please, check all them because I'm not sure if all these changes could lead to other problems in other AquaSim modules (there are fixes made to the phy module):
- There is a call to RemoveHeader in the AquaSimRouting::Recv method and no header is attached to the the packet the first time it is sent to the routing layer. This is a problem when the size of the packet passed to AquaSimNetDevice::Send was less than the AquaSim header's size. In order to fix this, an AquaSimHeader  has been attached to the packet in the AquaSimNetDevice::Send method before being sent to the lower layers. Here the AquaSimHeader::SetSize method is called passing the actual size of the packet.
- Since some fields of the AquaSimHeader and other headers could only be used to pass information between layers (these bits should not be transmitted), the actual size of the packet to be taken into account when calculating the transmission time should be the one indicated in the AquaSimHeader with the AquaSimheader::SetSize method (I'm right?). If this is the case, all layers must update this value appropriately. In addition, the transmission time should be obtained taking into account this value instead of obtaining the size of the packet by directly calling  the Packet::GetSize method (see https://github.com/rmartin5/aqua-sim-ng/blob/d6ee759e07e501321a923ba3a51d1c2936642447/model/aqua-sim-signal-cache.cc#L85 and https://github.com/rmartin5/aqua-sim-ng/blob/d6ee759e07e501321a923ba3a51d1c2936642447/model/aqua-sim-phy-cmn.cc#L474).
- In AquaSimAloha::SendPkt: the Timer thrown to wait for an ACK was not correctly estimating the RTT. 
This caused the retransmission of the packets even though the ACKs were received (see https://github.com/rmartin5/aqua-sim-ng/blob/d6ee759e07e501321a923ba3a51d1c2936642447/model/aqua-sim-mac-aloha.cc#L241).
- Add dependency with the internet module to avoid build errors: https://github.com/dcentelles/aqua-sim-ng/commit/9621588d79c6cc388eb7ca701126f122ce7e16b1
**Minor fixes:**
- Reduce redundancy in energy and power attributes.
- fix AquaSimNetDevice::Send when the routing layer is disabled and add MAC callbacks (https://github.com/dcentelles/aqua-sim-ng/commit/9b7ae0183dd0d210775131a2b21196461513dd76)
- Add more trace callbacks and log messages.
