### PR TITLE
fixes in AquaSimHeader and S-FAMA and other changes

### DIFF
--- a/model/aqua-sim-header-mac.cc
+++ b/model/aqua-sim-header-mac.cc
@@ -648,10 +648,10 @@ SFamaHeader::GetTypeId()
 int
 SFamaHeader::GetSize(enum PacketType pType)
 {
-  int pkt_size = 2*sizeof(Address); //source and destination addr in hdr_mac
+  int pkt_size = 2*sizeof(uint16_t)+1; //source and destination addr AND packet_type
 
   if( pType == SFAMA_RTS || pType == SFAMA_CTS ) {
-    pkt_size += sizeof(uint16_t)+1; //size of packet_type and slotnum
+    pkt_size += sizeof(uint16_t); //slotnum
   }
 
   return pkt_size;

--- a/model/aqua-sim-header-mac.cc
+++ b/model/aqua-sim-header-mac.cc
@@ -375,6 +375,11 @@ AlohaHeader::GetPType()
 {
   return m_pType;
 }
+int
+AlohaHeader::GetSize()
+{
+  return 2+2+1+2; //src, dst, type, crc16
+}
 
 uint32_t
 AlohaHeader::GetSerializedSize(void) const
@@ -648,7 +653,7 @@ SFamaHeader::GetTypeId()
 int
 SFamaHeader::GetSize(enum PacketType pType)
 {
-  int pkt_size = 2*sizeof(uint16_t)+1; //source and destination addr AND packet_type
+  int pkt_size = 2*sizeof(uint16_t)+1+2; //source and destination address, packet_type and crc16
 
   if( pType == SFAMA_RTS || pType == SFAMA_CTS ) {
     pkt_size += sizeof(uint16_t); //slotnum

--- a/model/aqua-sim-header-mac.cc
+++ b/model/aqua-sim-header-mac.cc
@@ -378,7 +378,7 @@ AlohaHeader::GetPType()
 int
 AlohaHeader::GetSize()
 {
-  return 2+2+1+2; //src, dst, type, crc16
+  return 2+2+1; //src, dst, type
 }
 
 uint32_t
@@ -653,7 +653,7 @@ SFamaHeader::GetTypeId()
 int
 SFamaHeader::GetSize(enum PacketType pType)
 {
-  int pkt_size = 2*sizeof(uint16_t)+1+2; //source and destination address, packet_type and crc16
+  int pkt_size = 2*sizeof(uint16_t)+1; //source and destination address, packet_type
 
   if( pType == SFAMA_RTS || pType == SFAMA_CTS ) {
     pkt_size += sizeof(uint16_t); //slotnum

--- a/model/aqua-sim-header-mac.h
+++ b/model/aqua-sim-header-mac.h
@@ -157,7 +157,7 @@ public:
   virtual ~AlohaHeader();
   static TypeId GetTypeId(void);
 
-  static int size();
+  static int GetSize();
 
   void SetSA(AquaSimAddress sa);
   void SetDA(AquaSimAddress da);

--- a/model/aqua-sim-header.cc
+++ b/model/aqua-sim-header.cc
@@ -41,7 +41,7 @@ NS_OBJECT_ENSURE_REGISTERED(AquaSimHeader);
 AquaSimHeader::AquaSimHeader(void) :
     m_txTime(0), m_direction(DOWN),
     m_numForwards(0), m_errorFlag(0), m_uId(-1),
-    m_size(0), m_timestamp(0)
+    m_size(0), m_timestamp(0), m_seq(0)
 {
   m_nextHop = AquaSimAddress(-1);
   m_src.addr = AquaSimAddress(-1);
@@ -84,6 +84,7 @@ AquaSimHeader::Deserialize(Buffer::Iterator start)
   m_nextHop = (AquaSimAddress) i.ReadU16();
   m_src.addr = (AquaSimAddress) i.ReadU16();
   m_dst.addr = (AquaSimAddress) i.ReadU16();
+  m_seq = i.ReadU32();
   m_errorFlag = i.ReadU8();	//wasted space due to only needing 1 bit
   m_uId = i.ReadU16();
   m_timestamp = Seconds ( ( (double) i.ReadU32 ()) / 1000.0 );
@@ -100,7 +101,7 @@ AquaSimHeader::GetSerializedSize(void) const
   example can be seen @ main-packet-header.cc*/
 
   //reserved bytes for header
-  return (4+2+1+2+1+2+2+2+2+4);
+  return (4+2+1+2+1+2+2+2+2+4+4);
 }
 
 void
@@ -114,6 +115,7 @@ AquaSimHeader::Serialize(Buffer::Iterator start) const
   i.WriteU16(m_nextHop.GetAsInt());
   i.WriteU16(m_src.addr.GetAsInt());
   i.WriteU16(m_dst.addr.GetAsInt());
+  i.WriteU32(m_seq);
   i.WriteU8(m_errorFlag);
   i.WriteU16(m_uId);
   //src/dst port
@@ -212,6 +214,11 @@ AquaSimHeader::GetTimeStamp()
   return m_timestamp;
 }
 
+uint32_t AquaSimHeader::GetSeqNum()
+{
+  return m_seq;
+}
+
 void
 AquaSimHeader::SetTxTime(Time time)
 {
@@ -285,6 +292,11 @@ AquaSimHeader::SetTimeStamp(Time timestamp)
   m_timestamp = timestamp;
 }
 
+void
+AquaSimHeader::SetSeqNum(const uint32_t & seqnum)
+{
+  m_seq = seqnum;
+}
 
 //PacketStampHeader
 

--- a/model/aqua-sim-header.cc
+++ b/model/aqua-sim-header.cc
@@ -77,7 +77,7 @@ uint32_t
 AquaSimHeader::Deserialize(Buffer::Iterator start)
 {
   Buffer::Iterator i = start;
-  m_txTime = Seconds ( ( (double) i.ReadU32 ()) / 1000.0 );
+  m_txTime = Seconds ( (double) (i.ReadU64() / 1e9));
   m_size = i.ReadU16();
   m_direction = i.ReadU8();
   m_numForwards = i.ReadU16();
@@ -101,14 +101,14 @@ AquaSimHeader::GetSerializedSize(void) const
   example can be seen @ main-packet-header.cc*/
 
   //reserved bytes for header
-  return (4+2+1+2+1+2+2+2+2+4+4);
+  return (8+2+1+2+1+2+2+2+2+4+4);
 }
 
 void
 AquaSimHeader::Serialize(Buffer::Iterator start) const
 {
   Buffer::Iterator i = start;
-  i.WriteU32((uint32_t)(m_txTime.GetSeconds() * 1000.0));
+  i.WriteU64((uint64_t)(m_txTime.GetSeconds() * 1e9)); //nanos
   i.WriteU16(m_size);
   i.WriteU8(m_direction);
   i.WriteU16(m_numForwards);

--- a/model/aqua-sim-header.h
+++ b/model/aqua-sim-header.h
@@ -74,6 +74,7 @@ public:
   bool GetErrorFlag();
   uint16_t GetUId();
   Time GetTimeStamp();
+  uint32_t GetSeqNum();
 
   //Setters
   void SetTxTime(Time time);
@@ -88,6 +89,7 @@ public:
   void SetErrorFlag(bool error);
   void SetUId(uint16_t uId);
   void SetTimeStamp(Time timestamp);
+  void SetSeqNum(const uint32_t & seq);
 
   //inherited by Header class
   virtual TypeId GetInstanceTypeId(void) const;
@@ -109,6 +111,7 @@ private:
   uint16_t m_uId;
   uint16_t m_size; //figmented size of packet...
   Time m_timestamp;
+  uint32_t m_seq;
 
 }; //class AquaSimHeader
 

--- a/model/aqua-sim-mac-aloha.cc
+++ b/model/aqua-sim-mac-aloha.cc
@@ -199,25 +199,23 @@ bool AquaSimAloha::TxProcess(Ptr<Packet> pkt)
 
 void AquaSimAloha::SendDataPkt()
 {
-	NS_LOG_FUNCTION(this);
-  double P = m_rand->GetValue(0,1);
-  Ptr<Packet> tmp = PktQ_.front();
-  AquaSimHeader asHeader;
-	tmp->PeekHeader(asHeader);
-  AquaSimAddress recver = asHeader.GetNextHop();
+  NS_LOG_FUNCTION(this);
+  if(!PktQ_.empty())
+  {
+      double P = m_rand->GetValue(0,1);
+      Ptr<Packet> tmp = PktQ_.front();
 
-  ALOHA_Status = SEND_DATA;
+      ALOHA_Status = SEND_DATA;
 
-  if( P<=m_persistent ) {
-    if( asHeader.GetNextHop() == recver ) //why? {
-	SendPkt(tmp->Copy());
+      if( P<=m_persistent ) {
+            SendPkt(tmp->Copy());
+      }
+      else {
+        //Binary Exponential Backoff
+        m_boCounter--;
+        DoBackoff();
+      }
   }
-  else {
-    //Binary Exponential Backoff
-    m_boCounter--;
-    DoBackoff();
-  }
-
   return;
 }
 

--- a/model/aqua-sim-mac-aloha.cc
+++ b/model/aqua-sim-mac-aloha.cc
@@ -166,7 +166,7 @@ bool AquaSimAloha::TxProcess(Ptr<Packet> pkt)
   AlohaHeader alohaH;
   pkt->RemoveHeader(asHeader);
   //pkt->RemoveHeader(alohaH);	This may need to be fixed for multi hop.
-        asHeader.SetSize(alohaH.GetSerializedSize()+asHeader.GetSize());
+        asHeader.SetSize(alohaH.GetSize()+asHeader.GetSize());
   asHeader.SetTxTime(GetTxTime(asHeader.GetSize()));
   asHeader.SetErrorFlag(false);
   asHeader.SetDirection(AquaSimHeader::DOWN);
@@ -235,7 +235,7 @@ void AquaSimAloha::SendPkt(Ptr<Packet> pkt)
 
   //compute estimated RTT
   Time txtime = asHeader.GetTxTime();
-  Time ertt = txtime + GetTxTime(alohaH.GetSerializedSize()*2) + Seconds(m_maxPropDelay*2);
+  Time ertt = txtime + GetTxTime(alohaH.GetSize()*2) + Seconds(m_maxPropDelay*2);
 
   switch( m_device->GetTransmissionStatus() ) {
     case SLEEP:
@@ -357,7 +357,7 @@ bool AquaSimAloha::RecvProcess(Ptr<Packet> pkt)
                         auto cpkt = pkt->Copy();
                         pkt->AddHeader(asHeader);
                         cpkt->RemoveHeader(alohaH);
-                        asHeader.SetSize(asHeader.GetSize() - alohaH.GetSerializedSize());
+                        asHeader.SetSize(asHeader.GetSize() - alohaH.GetSize());
                         cpkt->AddHeader(asHeader);
                         SendUp(cpkt);
 
@@ -395,8 +395,8 @@ Ptr<Packet> AquaSimAloha::MakeACK(AquaSimAddress Data_Sender)
   AlohaHeader alohaH;
 	AquaSimPtTag ptag;
 
-        asHeader.SetSize(alohaH.GetSerializedSize());
-  asHeader.SetTxTime(GetTxTime(alohaH.GetSerializedSize()));
+        asHeader.SetSize(alohaH.GetSize());
+  asHeader.SetTxTime(GetTxTime(alohaH.GetSize()));
   asHeader.SetErrorFlag(false);
   asHeader.SetDirection(AquaSimHeader::DOWN);
   asHeader.SetNextHop(Data_Sender);

--- a/model/aqua-sim-mac-aloha.cc
+++ b/model/aqua-sim-mac-aloha.cc
@@ -235,7 +235,10 @@ void AquaSimAloha::SendPkt(Ptr<Packet> pkt)
 
   //compute estimated RTT
   Time txtime = asHeader.GetTxTime();
-  Time ertt = txtime + GetTxTime(alohaH.GetSize()*2) + Seconds(m_maxPropDelay*2);
+  NS_LOG_DEBUG("pkt txTime: " << txtime.GetSeconds() << "("<<asHeader.GetSize()<<")");
+  NS_LOG_DEBUG("AlohaHeader txTime: " << GetTxTime(alohaH.GetSize()) << " (" << alohaH.GetSize() << ")");
+  NS_LOG_DEBUG("PropDelay: " << m_maxPropDelay);
+  Time ertt = txtime + GetTxTime(alohaH.GetSize()) + GetTxTime(alohaH.GetSize()) + Seconds(m_maxPropDelay*2);
 
   switch( m_device->GetTransmissionStatus() ) {
     case SLEEP:

--- a/model/aqua-sim-mac-aloha.cc
+++ b/model/aqua-sim-mac-aloha.cc
@@ -57,7 +57,7 @@ AquaSimAloha::~AquaSimAloha()
 
 void AquaSimAloha::Init()
 {
-    m_maxPropDelay = m_maxTransmitDistance/1500.0;
+    m_maxPropDelay = m_maxTransmitDistance / Device()->GetPropSpeed();
 }
 
 

--- a/model/aqua-sim-mac-aloha.h
+++ b/model/aqua-sim-mac-aloha.h
@@ -34,7 +34,7 @@
 
 
 #define CALLBACK_DELAY 0.001	//the interval between two consecutive sendings
-#define MAXIMUMCOUNTER 3
+#define MAXIMUMCOUNTER UINT16_MAX
 //#define Broadcast -1
 
 namespace ns3 {

--- a/model/aqua-sim-mac-sfama.cc
+++ b/model/aqua-sim-mac-sfama.cc
@@ -59,7 +59,7 @@ void AquaSimSFama_DataSend_Timer::expire()
 }
 
 
-AquaSimSFama::AquaSimSFama():m_status(IDLE_WAIT), m_guardTime(0.015),
+AquaSimSFama::AquaSimSFama():m_status(IDLE_WAIT), m_guardTime(0.005),
     m_slotLen(0), m_isInRound(false), m_isInBackoff(false),
     m_maxBackoffSlots(20), m_maxBurst(1), m_dataSendingInterval(0.0000001),
   m_waitSendTimer(this), m_waitReplyTimer(this),

--- a/model/aqua-sim-mac-sfama.cc
+++ b/model/aqua-sim-mac-sfama.cc
@@ -204,6 +204,8 @@ AquaSimSFama::GetTime2ComingSlot(double t)
     NS_LOG_FUNCTION(AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt() << t);
 	double numElapseSlot = t/m_slotLen;
     double res = m_slotLen*(std::ceil(numElapseSlot))-t;
+    if(res < 0)
+        res = 0;
 
     NS_LOG_DEBUG(AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt() << "; GetTime2ComingSlot. Elapsed slots: " << numElapseSlot << " ; Time to coming slot: " << res << " (slot len.: " << m_slotLen << ")");
 

--- a/model/aqua-sim-mac-sfama.cc
+++ b/model/aqua-sim-mac-sfama.cc
@@ -191,6 +191,7 @@ AquaSimSFama::InitSlotLen()
   double txTimeSec = txTime.ToDouble(Time::S);
   double prTimeSec = Device()->GetPhy()->GetTransRange()/Device()->GetPropSpeed();
   slotLen = m_guardTime + txTimeSec + prTimeSec;
+  m_maxPrTimeSec = prTimeSec;
 
   m_slotLen = slotLen;
 
@@ -672,7 +673,7 @@ NS_LOG_DEBUG(PrintAllQ());
 #endif
 
     NS_LOG_DEBUG(AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt() << "; txTime = " << txtime << " ; T.Bytes = " << bytes << " ; Q.Size = " << q_size);
-	txtime += (q_size-1)*m_dataSendingInterval;
+    txtime += (q_size-1)*m_dataSendingInterval + m_maxPrTimeSec;
 
 	return txtime;
 }

--- a/model/aqua-sim-mac-sfama.cc
+++ b/model/aqua-sim-mac-sfama.cc
@@ -295,9 +295,12 @@ AquaSimSFama::FillDATA(Ptr<Packet> data_pkt)
   MacHeader mach;
   data_pkt->RemoveHeader(ash);
 
+
   ash.SetSize(ash.GetSize()+SFAMAh.GetSize(SFamaHeader::SFAMA_DATA));
-  ash.SetTxTime(GetTxTime(ash.GetSize()) );
-  NS_LOG_DEBUG(AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt() << "; New Data Pkt to transmit = " << ash.GetSize() << " bytes ; TxTime = " << ash.GetTxTime().ToDouble(Time::S));
+  auto bytes = ash.GetSize();
+  auto txtime = GetTxTime(bytes);
+  ash.SetTxTime(txtime);
+  NS_LOG_DEBUG(AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt() << "; New Data Pkt to transmit = " << bytes << " bytes ; TxTime = " << txtime.ToDouble(Time::S));
   ash.SetErrorFlag(false);
   ash.SetDirection(AquaSimHeader::DOWN);
 
@@ -820,6 +823,8 @@ AquaSimSFama::StatusProcess(int slotnum)
 // 	}
 
 	//if( ! status_handler.is_ack() ) {
+  if(m_waitReplyTimer.IsRunning())
+      return;
   m_waitReplyTimer.SetFunction(&AquaSimSFama_Wait_Reply_Timer::expire,&m_waitReplyTimer);
   m_waitReplyTimer.Schedule(Seconds(m_slotLen*slotnum+GetTime2ComingSlot(Simulator::Now().ToDouble(Time::S))));
 	//}

--- a/model/aqua-sim-mac-sfama.h
+++ b/model/aqua-sim-mac-sfama.h
@@ -195,6 +195,7 @@ private:
 	double m_guardTime;  //need to be binded
 	double m_slotLen;
     double m_rtsCtsAckNumSlotWait;
+    double m_maxPrTimeSec;
 
 	bool m_isInRound;
 	bool m_isInBackoff;

--- a/model/aqua-sim-mac-sfama.h
+++ b/model/aqua-sim-mac-sfama.h
@@ -194,6 +194,7 @@ private:
 	//index_ is the mac address of this node
 	double m_guardTime;  //need to be binded
 	double m_slotLen;
+    double m_rtsCtsAckNumSlotWait;
 
 	bool m_isInRound;
 	bool m_isInBackoff;

--- a/model/aqua-sim-mac-sfama.h
+++ b/model/aqua-sim-mac-sfama.h
@@ -203,6 +203,7 @@ private:
 
 	int m_maxBurst; /*maximum number of packets in the train*/
 	double m_dataSendingInterval;
+    double m_lastRxDataSlotsNum;
 
 	//wait to send pkt at the beginning of next slot
 	AquaSimSFama_Wait_Send_Timer m_waitSendTimer;

--- a/model/aqua-sim-mac.h
+++ b/model/aqua-sim-mac.h
@@ -107,6 +107,7 @@ public:
 
   bool SendQueueEmpty();
   std::pair<Ptr<Packet>,TransStatus> SendQueuePop();
+  void SendQueuePush(std::pair<Ptr<Packet>, TransStatus>);
 
   double GetBitRate();
   double GetEncodingEff();
@@ -141,6 +142,10 @@ protected:
   virtual void DoDispose();
 
   bool m_dummyRouting; //See Attribute description in .cpp for more info
+  TracedValue<uint32_t> m_currentTxFifoSize, m_txPacketDrops, m_dataPktRetransmissions;
+
+  void InitTracedValues();
+  void StartTracedValues();
 };  //class AquaSimMac
 
 }  // namespace ns3

--- a/model/aqua-sim-net-device.cc
+++ b/model/aqua-sim-net-device.cc
@@ -712,3 +712,9 @@ AquaSimNetDevice::GetTransmissionStatus(void)
 {
   return m_transStatus;
 }
+
+double
+AquaSimNetDevice::GetPropSpeed()
+{
+    return 1500;
+}

--- a/model/aqua-sim-net-device.cc
+++ b/model/aqua-sim-net-device.cc
@@ -563,6 +563,51 @@ AquaSimNetDevice::NeedsArp (void) const
   return false;
 }
 
+
+bool
+AquaSimNetDevice::SendWithHeader(Ptr<Packet> packet, uint16_t protocolNumber){
+    AquaSimHeader ash;
+    packet->RemoveHeader(ash);
+    Address dest = ash.GetDAddr();
+    uint32_t pktSize = ash.GetSize();
+
+    //Quick hack. Named Data should be NULL pointer if unused/unset.
+    if (m_ndn)
+    {
+      return m_ndn->Recv(packet);
+    }
+
+    if(m_routing)
+      {//Note : https://www.nsnam.org/docs/release/3.24/doxygen/uan-mac-cw_8cc_source.html#l00123
+        ash.SetNextHop(AquaSimAddress::GetBroadcast());
+        packet->AddHeader(ash);
+        NS_LOG_DEBUG("Me(" << AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt()  << "): Sending packet to Routing layer : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
+        return m_routing->Recv(packet, dest, protocolNumber);
+      }
+    else if (MacEnabled() && m_mac)
+      {
+        ash.SetNextHop(ash.GetDAddr());
+        packet->AddHeader(ash);
+        NS_LOG_DEBUG("Me(" << AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt()  << "): Sending packet to MAC layer : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
+        return m_mac->TxProcess(packet);
+      }
+    else if (m_phy)
+      {
+        SetTransmissionStatus(SEND);
+        ash.SetNextHop(ash.GetDAddr());
+        ash.SetTxTime(m_phy->CalcTxTime(pktSize));
+        NS_LOG_DEBUG("Me(" << AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt()  << "): Sending packet to Phy layer : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
+        Simulator::Schedule(ash.GetTxTime(), &AquaSimNetDevice::SetTransmissionStatus,this, NIDLE);
+        packet->AddHeader(ash);
+        //slightly awkard but for phy header Buffer
+        AquaSimPacketStamp pstamp;
+        packet->AddHeader(pstamp);
+        return m_phy->PktTransmit(packet, 0);
+      }
+    else NS_LOG_WARN("Routing/Mac/Phy layers are not attached to this device. Can not send.");
+    return false;
+}
+
 bool
 AquaSimNetDevice::Send (Ptr< Packet > packet, const Address &dest, uint16_t protocolNumber)
 {
@@ -575,41 +620,8 @@ AquaSimNetDevice::Send (Ptr< Packet > packet, const Address &dest, uint16_t prot
   ash.SetSAddr(AquaSimAddress::ConvertFrom(GetAddress()));
   ash.SetDAddr(AquaSimAddress::ConvertFrom(dest));
 
-  //Quick hack. Named Data should be NULL pointer if unused/unset.
-  if (m_ndn)
-  {
-    return m_ndn->Recv(packet);
-  }
-
-  if(m_routing)
-    {//Note : https://www.nsnam.org/docs/release/3.24/doxygen/uan-mac-cw_8cc_source.html#l00123
-      ash.SetNextHop(AquaSimAddress::GetBroadcast());
-      packet->AddHeader(ash);
-      NS_LOG_DEBUG("Me(" << AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt()  << "): Sending packet to Routing layer : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
-      return m_routing->Recv(packet, dest, protocolNumber);
-    }
-  else if (MacEnabled() && m_mac)
-    {
-      ash.SetNextHop(ash.GetDAddr());
-      packet->AddHeader(ash);
-      NS_LOG_DEBUG("Me(" << AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt()  << "): Sending packet to MAC layer : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
-      return m_mac->TxProcess(packet);
-    }
-  else if (m_phy)
-    {
-      SetTransmissionStatus(SEND);
-      ash.SetNextHop(ash.GetDAddr());
-      ash.SetTxTime(m_phy->CalcTxTime(pktSize));
-      NS_LOG_DEBUG("Me(" << AquaSimAddress::ConvertFrom(GetAddress()).GetAsInt()  << "): Sending packet to Phy layer : " << ash.GetSize() << " bytes ; " << ash.GetTxTime().GetSeconds() << " sec. ; Dest: " << ash.GetDAddr().GetAsInt() << " ; Src: " << ash.GetSAddr().GetAsInt() << " ; Next H.: " << ash.GetNextHop().GetAsInt());
-      Simulator::Schedule(ash.GetTxTime(), &AquaSimNetDevice::SetTransmissionStatus,this, NIDLE);
-      packet->AddHeader(ash);
-      //slightly awkard but for phy header Buffer
-      AquaSimPacketStamp pstamp;
-      packet->AddHeader(pstamp);
-      return m_phy->PktTransmit(packet, 0);
-    }
-  else NS_LOG_WARN("Routing/Mac/Phy layers are not attached to this device. Can not send.");
-  return false;
+  packet->AddHeader(ash);
+  return SendWithHeader(packet, protocolNumber);
 }
 
 bool

--- a/model/aqua-sim-net-device.h
+++ b/model/aqua-sim-net-device.h
@@ -99,6 +99,8 @@ public:
   virtual void DoDispose (void);
   virtual void DoInitialize (void);
 
+  virtual double GetPropSpeed(void); //m/s
+
   void ForwardUp (Ptr<Packet> packet, Ptr<MobilityModel> src, Ptr<MobilityModel> dst);	//not used.
 
   //inherited functions from NetDevice class

--- a/model/aqua-sim-net-device.h
+++ b/model/aqua-sim-net-device.h
@@ -117,6 +117,7 @@ public:
   virtual bool IsMulticast (void) const;
   virtual bool IsPointToPoint (void) const;
   virtual bool NeedsArp (void) const;
+  virtual bool SendWithHeader (Ptr<Packet> packet, uint16_t protocolNumber);
   virtual bool Send (Ptr<Packet> packet, const Address &dest, uint16_t protocolNumber);
   virtual bool SendFrom (Ptr<Packet> packet, const Address &source,
                            const Address &dest, uint16_t protocolNumber);

--- a/model/aqua-sim-net-device.h
+++ b/model/aqua-sim-net-device.h
@@ -151,8 +151,8 @@ public:
   inline double FailurePro(void) { return m_failurePro; }
   inline double FailureStatusPro(void) { return m_failureStatusPro; }
 
-  void SetTransmissionStatus(TransStatus status);
-  TransStatus GetTransmissionStatus(void);
+  virtual void SetTransmissionStatus(TransStatus status);
+  virtual TransStatus GetTransmissionStatus(void);
 
   inline bool CarrierSense(void) { return m_carrierSense; }
   inline void ResetCarrierSense(void) { m_carrierSense = false; }


### PR DESCRIPTION
I think the most important fixes have been:
- [rev](https://github.com/rmartin5/aqua-sim-ng/commit/a7f38a926b678c36b442b5ca08257239dc0d58be): SFAMA kept WAIT_RECV_ACK status when losing ACK (the guard interval change made in this commit has been reverted in the next one)
- [rev](https://github.com/rmartin5/aqua-sim-ng/commit/7d4c9166c134ae9187e4ac60742a00af6e5dffa4): The tx time was encoded incorrectly in the AquaSimHeader. This was causing a loss of precision each time a packet was enqueued in the transmission queue, which was producing wrong behaviors in some congested links.