### PR TITLE
Added LIBRA MAC protocol, fixed issues with SFAMA and PHY-layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pyc
+scripts/*.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 build_lib(
     LIBNAME aqua-sim-ng
     SOURCE_FILES
+        model/aqua-sim-application.cc
         model/aqua-sim-address.cc
         model/aqua-sim-pt-tag.cc
         model/aqua-sim-channel.cc
@@ -31,6 +32,7 @@ build_lib(
         model/aqua-sim-mac-copemac.cc
         model/aqua-sim-mac-goal.cc
         model/aqua-sim-mac-sfama.cc
+        model/aqua-sim-mac-libra.cc
         model/aqua-sim-mac-uwan.cc
         model/aqua-sim-rmac.cc
         model/aqua-sim-rmac-buffer.cc
@@ -62,12 +64,14 @@ build_lib(
         model/ndn/onoff-nd-application.cc
         helper/named-data-helper.cc
         helper/on-off-nd-helper.cc
+        helper/aqua-sim-application-helper.cc
         helper/aqua-sim-traffic-gen-helper.cc
         model/aqua-sim-traffic-gen.cc
         model/aqua-sim-routing-dummy.cc
         model/aqua-sim-routing-ddbr.cc
         model/lib/svm.cpp
     HEADER_FILES
+        model/aqua-sim-application.h
         model/aqua-sim-address.h
         model/aqua-sim-pt-tag.h
         model/aqua-sim-channel.h
@@ -98,6 +102,7 @@ build_lib(
         model/aqua-sim-mac-copemac.h
         model/aqua-sim-mac-goal.h
         model/aqua-sim-mac-sfama.h
+        model/aqua-sim-mac-libra.h
         model/aqua-sim-mac-uwan.h
         model/aqua-sim-rmac.h
         model/aqua-sim-rmac-buffer.h
@@ -130,6 +135,7 @@ build_lib(
         model/ndn/onoff-nd-application.h
         helper/named-data-helper.h
         helper/on-off-nd-helper.h
+        helper/aqua-sim-application-helper.h
         helper/aqua-sim-traffic-gen-helper.h
         model/aqua-sim-traffic-gen.h
         model/aqua-sim-routing-dummy.h
@@ -223,3 +229,32 @@ build_lib_example(
                       ${libaqua-sim-ng}
 )
 
+build_lib_example(
+    NAME LibraGridTest
+    SOURCE_FILES examples/libra_grid_test.cc
+    LIBRARIES_TO_LINK ${libnetwork}
+                      ${libenergy}
+                      ${libmobility}
+                      ${libapplications}
+                      ${libaqua-sim-ng}
+)
+
+build_lib_example(
+    NAME AlohaGridTest
+    SOURCE_FILES examples/aloha_grid_test.cc
+    LIBRARIES_TO_LINK ${libnetwork}
+                      ${libenergy}
+                      ${libmobility}
+                      ${libapplications}
+                      ${libaqua-sim-ng}
+)
+
+build_lib_example(
+    NAME SfamaGridTest
+    SOURCE_FILES examples/sfama_grid_test.cc
+    LIBRARIES_TO_LINK ${libnetwork}
+                      ${libenergy}
+                      ${libmobility}
+                      ${libapplications}
+                      ${libaqua-sim-ng}
+)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,65 @@ After that, you should be able to run example scripts located under `src/aqua-si
 --------------------------------------
 ## Running Examples
 
-TBD.
+### LIBRA MAC protocol example
+
+LIBRA MAC protocol is a MAC protocol for UWSNs with multi-hop transmission range control capabilities, powered by Reinforcement Learning for adaptive route selection. More description can be found in the paper [] (See `References` section down below).
+
+To run LIBRA simulations, execute `libra_grid_test.cc` script from `examples/` folder by running:
+
+```
+./ns3 run "LibraGridTest --lambda=0.01 --packet_size=800 --grid_size=10000 --range=3000 --n_nodes=128 --tx_power=60 --simStop=10000 --RngRun=0"
+```
+where:
+
+`LibraGridTest`: name of the simulation script that refers to `libra_grid_test.cc`
+
+`--lambda`: application traffic rate, following Poisson distribution, pkts/sec
+
+`--packet_size`: user packet size, bytes
+
+`--grid_size`: size of the node allocation area, X by X meters
+
+`--range`: maximum transmission range, meters
+
+`--n_nodes`: number of nodes to allocate
+
+`--tx_power`: maximum Tx power, Watts
+
+`--simStop`: total simulation time, seconds
+
+`--RngRun`: seed for random generator
+
+After successful run, the script should generate a simulation trace-file with the following name: `libra-density-trace-0.01-128-0.asc`
+
+The trace-file contains raw simulation logs with every Tx/Rx event traced in a specific format. To extract useful data from the trace-file, such as network throughput, PDR, and more, please refer to `print_results_libra.py` script, located under `scripts/` folder.
+
+After executing the script, the parsed `.txt` file should be generated that will contain network metrics. An example of the parsed `libra-density-0.01.txt` content is the following:
+
+```
+Density	NodesNumber	Lambda	TxPackets	RxPackets	TxCount	RxCount	CollisionCount	TotalEnergyConsumption	EnergyPerBit	TotalThroughput	PDR	AvgHopCount
+1.28	128	0.01	12871	8936	22730	152065	174667	69036.9	0.0012	5709733134989.97	0.69	1.89
+d
+```
+
+### ALOHA and SFAMA simulations
+
+Similar to `LIBRA` simulations described above, the following scripts are available for `ALOHA` and `SFAMA` protocols: `aloha_grid_test.cc` and `sfama_grid_test.cc`.
+
+The simulation commands are similar to `LIBRA` as well:
+
+```
+./ns3 run "AlohaGridTest --lambda=0.01 --packet_size=800 --grid_size=10000 --range=3000 --n_nodes=128 --tx_power=60 --simStop=10000 --RngRun=0"
+```
+
+and
+
+```
+./ns3 run "SfamaGridTest --lambda=0.01 --packet_size=800 --grid_size=10000 --range=3000 --n_nodes=128 --tx_power=60 --simStop=10000 --RngRun=0"
+```
+
+To process raw trace-files after simulations, similar Python-scripts are available: `print_results_aloha.py` and `print_results_sfama.py`.
+
 
 --------------------------------------
 ## Legacy Documentation
@@ -122,6 +180,11 @@ Like any other network type, UWSN are susceptible to attacks. By implementing ja
 ### Information-Centric Integration
 We implement adapted Named Data Networking (NDN) techniques alongside specialized NDN protocols for UWSNs. By implementing these features, we can better depict and evaluate the improvements NDN can have in this environment. This integration consists of introducing interest and data structured packets, Pending Interest Tables, Forwarding Information Bases, and Context Storages for overall NDN inclusion that is specialized for underwater. Additionally, we implement this module through a packet demux on the physical layer, allowing for protocols to implement certain NDN features without completely revamping how our simulator functions.
 
+## References
+
+[1] Dugaev, D.; Peng, Z.; Luo, Y.; Pu, L. Reinforcement-Learning Based Dynamic Transmission Range Adjustment in Medium Access Control for Underwater Wireless Sensor Networks. Electronics 2020, 9, 1727. https://doi.org/10.3390/electronics9101727
+
+
 --------------------------------------
 #### License and Contact
 
@@ -131,3 +194,5 @@ All rights reserved.
 Robert Martin : <robert.martin@uconn.edu>
 
 Zheng Peng, Ph.D : <zheng@cs.ccny.cuny.edu>
+
+Dmitrii Dugaev : <ddugaev@gradcenter.cuny.edu>

--- a/examples/aloha_grid_test.cc
+++ b/examples/aloha_grid_test.cc
@@ -1,0 +1,193 @@
+/*
+ * aloha_tests.cc
+ *
+ *  Created on: March 8, 2019
+ *      Author: dmitry
+ */
+
+
+#include "ns3/core-module.h"
+#include "ns3/network-module.h"
+#include "ns3/mobility-module.h"
+#include "ns3/aqua-sim-ng-module.h"
+#include "ns3/aqua-sim-propagation.h"
+#include "ns3/applications-module.h"
+#include "ns3/log.h"
+#include "ns3/callback.h"
+
+#include <random>
+#include <math.h>
+
+/*
+ * ALOHA NxN grid random destination topology tests
+ *
+ *
+ */
+
+using namespace ns3;
+
+NS_LOG_COMPONENT_DEFINE("ALOHA_grid_test");
+
+int
+main (int argc, char *argv[])
+{
+  double simStop = 100; //seconds
+//  double simStop = 2; //seconds
+
+  int n_nodes = 10;
+//  int sinks = 1;
+//  uint32_t m_dataRate = 80000; // bps
+  double m_dataRate = 80000; // bps
+
+  double m_packetSize = 50; // bytes
+  double range = 1500;	// meters
+
+  // Poisson traffic parameters
+  double lambda = 0.1;
+
+  // Grid parameters
+  int max_x = 100; // meters
+//  int max_y = 10000; // meters
+//  double distance = 10; // meters
+
+  // Max Tx power
+  double max_tx_power = 20; // Watts
+
+//  LogComponentEnable ("ASBroadcastMac", LOG_LEVEL_INFO);
+
+  //to change on the fly
+  CommandLine cmd;
+  cmd.AddValue ("simStop", "Length of simulation", simStop);
+  cmd.AddValue ("lambda", "Packet arrival rate", lambda);
+  cmd.AddValue ("packet_size", "Packet size", m_packetSize);
+  cmd.AddValue ("grid_size", "Grid size, in km", max_x);
+  cmd.AddValue ("n_nodes", "Number of nodes", n_nodes);
+  cmd.AddValue ("range", "Transmission range", range);
+  cmd.AddValue ("tx_power", "Max transmission power", max_tx_power);
+
+
+  cmd.Parse(argc,argv);
+
+  // Random integer selection-related parameters
+  std::random_device rd;     // only used once to initialise (seed) engine
+  std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
+  std::uniform_int_distribution<int> uni_distance(0, max_x); // guaranteed unbiased
+  std::uniform_int_distribution<int> uni_nodes(0, n_nodes - 1); // guaranteed unbiased
+
+
+  std::cout << "-----------Initializing simulation-----------\n";
+
+  NodeContainer nodesCon;
+//  NodeContainer sinksCon;
+  nodesCon.Create(n_nodes);
+//  sinksCon.Create(sinks);
+
+  PacketSocketHelper socketHelper;
+  socketHelper.Install(nodesCon);
+//  socketHelper.Install(sinksCon);
+
+  //establish layers using helper's pre-build settings
+  AquaSimChannelHelper channel = AquaSimChannelHelper::Default();
+  channel.SetPropagation("ns3::AquaSimRangePropagation");
+  AquaSimHelper asHelper = AquaSimHelper::Default();
+  asHelper.SetChannel(channel.Create());
+
+  asHelper.SetMac("ns3::AquaSimAloha", "AckOn", IntegerValue(0), "MinBackoff", DoubleValue(0.0),
+		  "MaxBackoff", DoubleValue(1.5));
+
+  asHelper.SetRouting("ns3::AquaSimRoutingDummy");
+
+  // Define the Tx power
+  asHelper.SetPhy("ns3::AquaSimPhyCmn", "PT", DoubleValue(max_tx_power));
+
+  /*
+   * Set up mobility model for nodes and sinks
+   */
+  MobilityHelper mobility;
+  NetDeviceContainer devices;
+  Ptr<ListPositionAllocator> position = CreateObject<ListPositionAllocator> ();
+  Vector boundry = Vector(0,0,0);
+
+  std::cout << "Creating Nodes\n";
+
+  for (NodeContainer::Iterator i = nodesCon.Begin(); i != nodesCon.End(); i++)
+    {
+      Ptr<AquaSimNetDevice> newDevice = CreateObject<AquaSimNetDevice>();
+
+      // Select random (x, y) position
+      boundry.x = uni_distance(rng);
+      boundry.y = uni_distance(rng);
+
+      position->Add(boundry);
+      devices.Add(asHelper.Create(*i, newDevice));
+
+//      NS_LOG_DEBUG("Node:" << newDevice->GetAddress() << " position(x):" << boundry.x);
+//      std::cout << "Node:" << newDevice->GetAddress() << " position(x):" << boundry.x <<
+//    		  " position(y):" << boundry.y << "\n";
+      newDevice->GetPhy()->SetTransRange(range);
+//      newDevice->GetPhy()->SetTxPower(0.001);
+    }
+
+  mobility.SetPositionAllocator(position);
+  mobility.SetMobilityModel("ns3::ConstantPositionMobilityModel");
+  mobility.Install(nodesCon);
+//  mobility.Install(sinksCon);
+
+  int j = 0;
+  char duration_on[300];
+  char duration_off[300];
+
+  // Set application to each node
+  for (NodeContainer::Iterator i = nodesCon.Begin(); i != nodesCon.End(); i++)
+  {
+	  AquaSimApplicationHelper app ("ns3::PacketSocketFactory", n_nodes);
+
+	  sprintf(duration_on, "ns3::ExponentialRandomVariable[Mean=%f]", (m_packetSize * 8) / m_dataRate);
+	  sprintf(duration_off, "ns3::ExponentialRandomVariable[Mean=%f]", 1 / lambda);
+//	  std::cout << "Duration On: " << duration_on << "\n";
+//	  std::cout << "Duration Off: " << duration_off << "\n";
+	  app.SetAttribute ("OnTime", StringValue (duration_on));
+	  app.SetAttribute ("OffTime", StringValue (duration_off));
+
+	  app.SetAttribute ("DataRate", DataRateValue (m_dataRate));
+	  app.SetAttribute ("PacketSize", UintegerValue (m_packetSize));
+
+	  ApplicationContainer apps = app.Install (nodesCon.Get(j));
+
+	  apps.Start (Seconds (0.5));
+	  apps.Stop (Seconds (simStop + 1));
+
+	  j++;
+  }
+
+  Packet::EnablePrinting (); //for debugging purposes
+  std::cout << "-----------Running Simulation-----------\n";
+  Simulator::Stop(Seconds(simStop));
+
+  // Enable ASCII trace files
+  Packet::EnablePrinting ();  //for debugging purposes
+  char buff[1000];
+  // Naming convention: lambda-number_of_nodes-n_intermediate_nodes-seed
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << lambda;
+  std::string lambda_string = stream.str();
+  snprintf(buff, sizeof(buff), "aloha-density-trace-%s-%d-%d.asc", lambda_string.c_str(), n_nodes, 0);
+  std::string asciiTraceFile = buff;
+
+  // std::string asciiTraceFile = "aloha-trace.asc";
+  // asciiTraceFile.
+  std::ofstream ascii (asciiTraceFile.c_str());
+  if (!ascii.is_open()) {
+    NS_FATAL_ERROR("Could not open trace file.");
+  }
+  asHelper.EnableAsciiAll(ascii);
+
+  Simulator::Run();
+
+  asHelper.GetChannel()->PrintCounters();
+
+  Simulator::Destroy();
+
+  std::cout << "fin.\n";
+  return 0;
+}

--- a/examples/libra_grid_test.cc
+++ b/examples/libra_grid_test.cc
@@ -1,0 +1,208 @@
+/*
+ * libra_tests
+ *
+ *  Created on: Aug 16, 2019
+ *      Author: dmitry
+ * 
+ * Added kinematic mobility model
+ */
+
+
+#include "ns3/core-module.h"
+#include "ns3/network-module.h"
+#include "ns3/mobility-module.h"
+#include "ns3/aqua-sim-ng-module.h"
+#include "ns3/aqua-sim-propagation.h"
+#include "ns3/applications-module.h"
+#include "ns3/log.h"
+#include "ns3/callback.h"
+
+#include <random>
+#include <math.h>
+#include <iomanip> // setprecision
+#include <sstream> // stringstream
+
+/*
+ * MAC-Libra NxN grid random destination topology tests
+ *
+ *
+ */
+
+using namespace ns3;
+
+NS_LOG_COMPONENT_DEFINE("MAC_libra_grid_test");
+
+int
+main (int argc, char *argv[])
+{
+  double simStop = 100; //seconds
+//  double simStop = 2; //seconds
+
+  int n_nodes = 10;
+//  int sinks = 1;
+//  uint32_t m_dataRate = 80000; // bps
+  double m_dataRate = 80000; // bps
+
+  double m_packetSize = 50; // bytes
+  double range = 1500;	// meters
+
+  // Poisson traffic parameters
+  double lambda = 0.1;
+
+  // Grid parameters
+  int max_x = 100; // meters
+//  int max_y = 10000; // meters
+//  double distance = 10; // meters
+
+  // Max Tx power
+  double max_tx_power = 60; // Watts
+
+  // Number of intermediate nodes (only for some experiments!!!)
+  int n_intermediate_nodes = 0;
+
+  //to change on the fly
+  CommandLine cmd;
+  cmd.AddValue ("simStop", "Length of simulation", simStop);
+  cmd.AddValue ("lambda", "Packet arrival rate", lambda);
+  cmd.AddValue ("packet_size", "Packet size", m_packetSize);
+  cmd.AddValue ("grid_size", "Grid size, in km", max_x);
+  cmd.AddValue ("n_nodes", "Number of nodes", n_nodes);
+  cmd.AddValue ("range", "Transmission range", range);
+  cmd.AddValue ("tx_power", "Max transmission power", max_tx_power);
+  cmd.AddValue ("intermediate_nodes", "Number of intermediate nodes", n_intermediate_nodes);
+
+
+  cmd.Parse(argc,argv);
+
+  // Random integer selection-related parameters
+  std::random_device rd;     // only used once to initialise (seed) engine
+  std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
+  std::uniform_int_distribution<int> uni_distance(0, max_x); // guaranteed unbiased
+  std::uniform_int_distribution<int> uni_nodes(0, n_nodes - 1); // guaranteed unbiased
+
+
+  std::cout << "-----------Initializing simulation-----------\n";
+
+  NodeContainer nodesCon;
+//  NodeContainer sinksCon;
+  nodesCon.Create(n_nodes);
+//  sinksCon.Create(sinks);
+
+  PacketSocketHelper socketHelper;
+  socketHelper.Install(nodesCon);
+//  socketHelper.Install(sinksCon);
+
+  //establish layers using helper's pre-build settings
+  AquaSimChannelHelper channel = AquaSimChannelHelper::Default();
+  channel.SetPropagation("ns3::AquaSimRangePropagation");
+  AquaSimHelper asHelper = AquaSimHelper::Default();
+  asHelper.SetChannel(channel.Create());
+
+  asHelper.SetMac("ns3::AquaSimMacLibra", "max_range", DoubleValue(range), "max_tx_power", DoubleValue(max_tx_power),
+  		  "packet_size", IntegerValue(m_packetSize), "intermediate_nodes", IntegerValue(n_intermediate_nodes));
+
+//    asHelper.SetMac("ns3::AquaSimSFama", "packet_size", DoubleValue(m_packetSize));
+//    asHelper.SetMac("ns3::AquaSimBroadcastMac");
+//  asHelper.SetMac("ns3::AquaSimAloha");
+
+  asHelper.SetRouting("ns3::AquaSimRoutingDummy");
+
+  // Define the Tx power
+  asHelper.SetPhy("ns3::AquaSimPhyCmn", "PT", DoubleValue(max_tx_power));
+
+
+  /*
+   * Set up mobility model for nodes and sinks
+   */
+  MobilityHelper mobility;
+  NetDeviceContainer devices;
+  Ptr<ListPositionAllocator> position = CreateObject<ListPositionAllocator> ();
+  Vector boundry = Vector(0,0,0);
+
+  std::cout << "Creating Nodes\n";
+
+  for (NodeContainer::Iterator i = nodesCon.Begin(); i != nodesCon.End(); i++)
+    {
+      Ptr<AquaSimNetDevice> newDevice = CreateObject<AquaSimNetDevice>();
+
+      // Select random (x, y) position
+      boundry.x = uni_distance(rng);
+      boundry.y = uni_distance(rng);
+
+      position->Add(boundry);
+      devices.Add(asHelper.Create(*i, newDevice));
+
+//      NS_LOG_DEBUG("Node:" << newDevice->GetAddress() << " position(x):" << boundry.x);
+//      std::cout << "Node:" << newDevice->GetAddress() << " position(x):" << boundry.x <<
+//    		  " position(y):" << boundry.y << "\n";
+      newDevice->GetPhy()->SetTransRange(range);
+//      newDevice->GetPhy()->SetTxPower(0.001);
+    }
+
+  mobility.SetPositionAllocator(position);
+  mobility.SetMobilityModel("ns3::ConstantPositionMobilityModel");
+  mobility.Install(nodesCon);
+//  mobility.Install(sinksCon);
+
+  int j = 0;
+  char duration_on[300];
+  char duration_off[300];
+
+  // Set application to each node
+  for (NodeContainer::Iterator i = nodesCon.Begin(); i != nodesCon.End(); i++)
+  {
+	  AquaSimApplicationHelper app ("ns3::PacketSocketFactory", n_nodes);
+
+	  sprintf(duration_on, "ns3::ExponentialRandomVariable[Mean=%f]", (m_packetSize * 8) / m_dataRate);
+	  sprintf(duration_off, "ns3::ExponentialRandomVariable[Mean=%f]", 1 / lambda);
+//	  std::cout << "Duration On: " << duration_on << "\n";
+//	  std::cout << "Duration Off: " << duration_off << "\n";
+	  app.SetAttribute ("OnTime", StringValue (duration_on));
+	  app.SetAttribute ("OffTime", StringValue (duration_off));
+
+	  app.SetAttribute ("DataRate", DataRateValue (m_dataRate));
+	  app.SetAttribute ("PacketSize", UintegerValue (m_packetSize));
+
+	  ApplicationContainer apps = app.Install (nodesCon.Get(j));
+
+	  // apps.Start (Seconds (0.5));
+	  // apps.Stop (Seconds (simStop + 1));
+
+      // Stop the application 30 seconds earlier - for more accurate throughput calculations
+      apps.Start (Seconds (1));
+	  apps.Stop (Seconds (simStop + 1));
+
+	  j++;
+  }
+
+  Packet::EnablePrinting (); //for debugging purposes
+  std::cout << "-----------Running Simulation-----------\n";
+  Simulator::Stop(Seconds(simStop + 30));
+
+  // Enable ASCII trace files
+  Packet::EnablePrinting ();  //for debugging purposes
+  char buff[1000];
+  // Naming convention: lambda-number_of_nodes-n_intermediate_nodes-seed
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << lambda;
+  std::string lambda_string = stream.str();
+  snprintf(buff, sizeof(buff), "libra-density-trace-%s-%d-%d.asc", lambda_string.c_str(), n_nodes, n_intermediate_nodes);
+  std::string asciiTraceFile = buff;
+
+  // std::string asciiTraceFile = "libra-trace.asc";
+  // asciiTraceFile.
+  std::ofstream ascii (asciiTraceFile.c_str());
+  if (!ascii.is_open()) {
+    NS_FATAL_ERROR("Could not open trace file.");
+  }
+  asHelper.EnableAsciiAll(ascii);
+
+  Simulator::Run();
+
+  asHelper.GetChannel()->PrintCounters();
+
+  Simulator::Destroy();
+
+  std::cout << "fin.\n";
+  return 0;
+}

--- a/examples/sfama_grid_test.cc
+++ b/examples/sfama_grid_test.cc
@@ -1,0 +1,192 @@
+/*
+ * sfama_tests.cc
+ *
+ *  Created on: March 8, 2019
+ *      Author: dmitry
+ */
+
+
+#include "ns3/core-module.h"
+#include "ns3/network-module.h"
+#include "ns3/mobility-module.h"
+#include "ns3/aqua-sim-ng-module.h"
+#include "ns3/aqua-sim-propagation.h"
+#include "ns3/applications-module.h"
+#include "ns3/log.h"
+#include "ns3/callback.h"
+
+#include <random>
+#include <math.h>
+
+/*
+ * SFAMA NxN grid random destination topology tests
+ *
+ *
+ */
+
+using namespace ns3;
+
+NS_LOG_COMPONENT_DEFINE("SFAMA_grid_test");
+
+int
+main (int argc, char *argv[])
+{
+  double simStop = 100; //seconds
+//  double simStop = 2; //seconds
+
+  int n_nodes = 10;
+//  int sinks = 1;
+//  uint32_t m_dataRate = 80000; // bps
+  double m_dataRate = 80000; // bps
+
+  double m_packetSize = 50; // bytes
+  double range = 1500;	// meters
+
+  // Poisson traffic parameters
+  double lambda = 0.1;
+
+  // Grid parameters
+  int max_x = 100; // meters
+//  int max_y = 10000; // meters
+//  double distance = 10; // meters
+
+  // Max Tx power
+  double max_tx_power = 20; // Watts
+
+//  LogComponentEnable ("ASBroadcastMac", LOG_LEVEL_INFO);
+
+  //to change on the fly
+  CommandLine cmd;
+  cmd.AddValue ("simStop", "Length of simulation", simStop);
+  cmd.AddValue ("lambda", "Packet arrival rate", lambda);
+  cmd.AddValue ("packet_size", "Packet size", m_packetSize);
+  cmd.AddValue ("grid_size", "Grid size, in km", max_x);
+  cmd.AddValue ("n_nodes", "Number of nodes", n_nodes);
+  cmd.AddValue ("range", "Transmission range", range);
+  cmd.AddValue ("tx_power", "Max transmission power", max_tx_power);
+
+
+  cmd.Parse(argc,argv);
+
+  // Random integer selection-related parameters
+  std::random_device rd;     // only used once to initialise (seed) engine
+  std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
+  std::uniform_int_distribution<int> uni_distance(0, max_x); // guaranteed unbiased
+  std::uniform_int_distribution<int> uni_nodes(0, n_nodes - 1); // guaranteed unbiased
+
+
+  std::cout << "-----------Initializing simulation-----------\n";
+
+  NodeContainer nodesCon;
+//  NodeContainer sinksCon;
+  nodesCon.Create(n_nodes);
+//  sinksCon.Create(sinks);
+
+  PacketSocketHelper socketHelper;
+  socketHelper.Install(nodesCon);
+//  socketHelper.Install(sinksCon);
+
+  //establish layers using helper's pre-build settings
+  AquaSimChannelHelper channel = AquaSimChannelHelper::Default();
+  channel.SetPropagation("ns3::AquaSimRangePropagation");
+  AquaSimHelper asHelper = AquaSimHelper::Default();
+  asHelper.SetChannel(channel.Create());
+
+  asHelper.SetMac("ns3::AquaSimSFama", "packet_size", DoubleValue(m_packetSize));
+
+  asHelper.SetRouting("ns3::AquaSimRoutingDummy");
+
+  // Define the Tx power
+  asHelper.SetPhy("ns3::AquaSimPhyCmn", "PT", DoubleValue(max_tx_power));
+
+  /*
+   * Set up mobility model for nodes and sinks
+   */
+  MobilityHelper mobility;
+  NetDeviceContainer devices;
+  Ptr<ListPositionAllocator> position = CreateObject<ListPositionAllocator> ();
+  Vector boundry = Vector(0,0,0);
+
+  std::cout << "Creating Nodes\n";
+
+  for (NodeContainer::Iterator i = nodesCon.Begin(); i != nodesCon.End(); i++)
+    {
+      Ptr<AquaSimNetDevice> newDevice = CreateObject<AquaSimNetDevice>();
+
+      // Select random (x, y) position
+      boundry.x = uni_distance(rng);
+      boundry.y = uni_distance(rng);
+
+      position->Add(boundry);
+      devices.Add(asHelper.Create(*i, newDevice));
+
+//      NS_LOG_DEBUG("Node:" << newDevice->GetAddress() << " position(x):" << boundry.x);
+//      std::cout << "Node:" << newDevice->GetAddress() << " position(x):" << boundry.x <<
+//    		  " position(y):" << boundry.y << "\n";
+      newDevice->GetPhy()->SetTransRange(range);
+//      newDevice->GetPhy()->SetTxPower(0.001);
+    }
+
+  mobility.SetPositionAllocator(position);
+  mobility.SetMobilityModel("ns3::ConstantPositionMobilityModel");
+  mobility.Install(nodesCon);
+//  mobility.Install(sinksCon);
+
+  int j = 0;
+  char duration_on[300];
+  char duration_off[300];
+
+  // Set application to each node
+  for (NodeContainer::Iterator i = nodesCon.Begin(); i != nodesCon.End(); i++)
+  {
+	  AquaSimApplicationHelper app ("ns3::PacketSocketFactory", n_nodes);
+
+	  sprintf(duration_on, "ns3::ExponentialRandomVariable[Mean=%f]", (m_packetSize * 8) / m_dataRate);
+	  sprintf(duration_off, "ns3::ExponentialRandomVariable[Mean=%f]", 1 / lambda);
+//	  std::cout << "Duration On: " << duration_on << "\n";
+//	  std::cout << "Duration Off: " << duration_off << "\n";
+	  app.SetAttribute ("OnTime", StringValue (duration_on));
+	  app.SetAttribute ("OffTime", StringValue (duration_off));
+
+	  app.SetAttribute ("DataRate", DataRateValue (m_dataRate));
+	  app.SetAttribute ("PacketSize", UintegerValue (m_packetSize));
+
+	  ApplicationContainer apps = app.Install (nodesCon.Get(j));
+
+	  apps.Start (Seconds (0.5));
+	  apps.Stop (Seconds (simStop + 1));
+
+	  j++;
+  }
+
+  Packet::EnablePrinting (); //for debugging purposes
+  std::cout << "-----------Running Simulation-----------\n";
+  Simulator::Stop(Seconds(simStop));
+
+  // Enable ASCII trace files
+  Packet::EnablePrinting ();  //for debugging purposes
+  char buff[1000];
+  // Naming convention: lambda-number_of_nodes-n_intermediate_nodes-seed
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << lambda;
+  std::string lambda_string = stream.str();
+  snprintf(buff, sizeof(buff), "sfama-density-trace-%s-%d-%d.asc", lambda_string.c_str(), n_nodes, 0);
+  std::string asciiTraceFile = buff;
+
+  // std::string asciiTraceFile = "sfama-trace.asc";
+  // asciiTraceFile.
+  std::ofstream ascii (asciiTraceFile.c_str());
+  if (!ascii.is_open()) {
+    NS_FATAL_ERROR("Could not open trace file.");
+  }
+  asHelper.EnableAsciiAll(ascii);
+
+  Simulator::Run();
+
+  asHelper.GetChannel()->PrintCounters();
+
+  Simulator::Destroy();
+
+  std::cout << "fin.\n";
+  return 0;
+}

--- a/helper/aqua-sim-application-helper.cc
+++ b/helper/aqua-sim-application-helper.cc
@@ -1,0 +1,101 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+Based on on-off-helper.cc
+ */
+
+#include "aqua-sim-application-helper.h"
+#include "ns3/inet-socket-address.h"
+#include "ns3/packet-socket-address.h"
+#include "ns3/string.h"
+#include "ns3/data-rate.h"
+#include "ns3/uinteger.h"
+#include "ns3/names.h"
+#include "ns3/random-variable-stream.h"
+#include "ns3/aqua-sim-application.h"
+
+namespace ns3 {
+
+AquaSimApplicationHelper::AquaSimApplicationHelper (std::string protocol, Address address)
+{
+  m_factory.SetTypeId ("ns3::AquaSimApplication");
+  m_factory.Set ("Protocol", StringValue (protocol));
+  m_factory.Set ("Remote", AddressValue (address));
+}
+
+AquaSimApplicationHelper::AquaSimApplicationHelper (std::string protocol, uint32_t n_destinations)
+{
+  m_factory.SetTypeId ("ns3::AquaSimApplication");
+  m_factory.Set ("Protocol", StringValue (protocol));
+  m_factory.Set ("NumberOfDestinations", UintegerValue (n_destinations));
+}
+
+void 
+AquaSimApplicationHelper::SetAttribute (std::string name, const AttributeValue &value)
+{
+  m_factory.Set (name, value);
+}
+
+ApplicationContainer
+AquaSimApplicationHelper::Install (Ptr<Node> node) const
+{
+  return ApplicationContainer (InstallPriv (node));
+}
+
+ApplicationContainer
+AquaSimApplicationHelper::Install (std::string nodeName) const
+{
+  Ptr<Node> node = Names::Find<Node> (nodeName);
+  return ApplicationContainer (InstallPriv (node));
+}
+
+ApplicationContainer
+AquaSimApplicationHelper::Install (NodeContainer c) const
+{
+  ApplicationContainer apps;
+  for (NodeContainer::Iterator i = c.Begin (); i != c.End (); ++i)
+    {
+      apps.Add (InstallPriv (*i));
+    }
+
+  return apps;
+}
+
+Ptr<Application>
+AquaSimApplicationHelper::InstallPriv (Ptr<Node> node) const
+{
+  Ptr<Application> app = m_factory.Create<Application> ();
+  node->AddApplication (app);
+
+  return app;
+}
+
+int64_t
+AquaSimApplicationHelper::AssignStreams (NodeContainer c, int64_t stream)
+{
+  int64_t currentStream = stream;
+  Ptr<Node> node;
+  for (NodeContainer::Iterator i = c.Begin (); i != c.End (); ++i)
+    {
+      node = (*i);
+      for (uint32_t j = 0; j < node->GetNApplications (); j++)
+        {
+          Ptr<AquaSimApplication> onoff = DynamicCast<AquaSimApplication> (node->GetApplication (j));
+          if (onoff)
+            {
+              currentStream += onoff->AssignStreams (currentStream);
+            }
+        }
+    }
+  return (currentStream - stream);
+}
+
+void 
+AquaSimApplicationHelper::SetConstantRate (DataRate dataRate, uint32_t packetSize)
+{
+  m_factory.Set ("OnTime", StringValue ("ns3::ConstantRandomVariable[Constant=1000]"));
+  m_factory.Set ("OffTime", StringValue ("ns3::ConstantRandomVariable[Constant=0]"));
+  m_factory.Set ("DataRate", DataRateValue (dataRate));
+  m_factory.Set ("PacketSize", UintegerValue (packetSize));
+}
+
+} // namespace ns3

--- a/helper/aqua-sim-application-helper.h
+++ b/helper/aqua-sim-application-helper.h
@@ -1,0 +1,118 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ */
+#ifndef AQUA_SIM_APP_HELPER_H
+#define AQUA_SIM_APP_HELPER_H
+
+#include <stdint.h>
+#include <string>
+#include "ns3/object-factory.h"
+#include "ns3/address.h"
+#include "ns3/attribute.h"
+#include "ns3/net-device.h"
+#include "ns3/node-container.h"
+#include "ns3/application-container.h"
+#include "ns3/onoff-application.h"
+
+namespace ns3 {
+
+class DataRate;
+
+/**
+ * \ingroup onoff
+ * \brief A helper to make it easier to instantiate an ns3::OnOffApplication 
+ * on a set of nodes.
+ */
+class AquaSimApplicationHelper
+{
+public:
+  /**
+   * Create an AquaSimApplicationHelper to make it easier to work with OnOffApplications
+   *
+   * \param protocol the name of the protocol to use to send traffic
+   *        by the applications. This string identifies the socket
+   *        factory type used to create sockets for the applications.
+   *        A typical value would be ns3::UdpSocketFactory.
+   * \param address the address of the remote node to send traffic
+   *        to.
+   */
+  AquaSimApplicationHelper (std::string protocol, Address address);
+
+  // For random destination
+  AquaSimApplicationHelper (std::string protocol, uint32_t n_destinations);
+
+  /**
+   * Helper function used to set the underlying application attributes.
+   *
+   * \param name the name of the application attribute to set
+   * \param value the value of the application attribute to set
+   */
+  void SetAttribute (std::string name, const AttributeValue &value);
+
+  /**
+   * Helper function to set a constant rate source.  Equivalent to
+   * setting the attributes OnTime to constant 1000 seconds, OffTime to 
+   * constant 0 seconds, and the DataRate and PacketSize set accordingly
+   *
+   * \param dataRate DataRate object for the sending rate
+   * \param packetSize size in bytes of the packet payloads generated
+   */
+  void SetConstantRate (DataRate dataRate, uint32_t packetSize = 512);
+
+  /**
+   * Install an ns3::OnOffApplication on each node of the input container
+   * configured with all the attributes set with SetAttribute.
+   *
+   * \param c NodeContainer of the set of nodes on which an OnOffApplication 
+   * will be installed.
+   * \returns Container of Ptr to the applications installed.
+   */
+  ApplicationContainer Install (NodeContainer c) const;
+
+  /**
+   * Install an ns3::OnOffApplication on the node configured with all the 
+   * attributes set with SetAttribute.
+   *
+   * \param node The node on which an OnOffApplication will be installed.
+   * \returns Container of Ptr to the applications installed.
+   */
+  ApplicationContainer Install (Ptr<Node> node) const;
+
+  /**
+   * Install an ns3::OnOffApplication on the node configured with all the 
+   * attributes set with SetAttribute.
+   *
+   * \param nodeName The node on which an OnOffApplication will be installed.
+   * \returns Container of Ptr to the applications installed.
+   */
+  ApplicationContainer Install (std::string nodeName) const;
+
+ /**
+  * Assign a fixed random variable stream number to the random variables
+  * used by this model.  Return the number of streams (possibly zero) that
+  * have been assigned.  The Install() method should have previously been
+  * called by the user.
+  *
+  * \param stream first stream index to use
+  * \param c NodeContainer of the set of nodes for which the OnOffApplication
+  *          should be modified to use a fixed stream
+  * \return the number of stream indices assigned by this helper
+  */
+  int64_t AssignStreams (NodeContainer c, int64_t stream);
+
+private:
+  /**
+   * Install an ns3::OnOffApplication on the node configured with all the 
+   * attributes set with SetAttribute.
+   *
+   * \param node The node on which an OnOffApplication will be installed.
+   * \returns Ptr to the application installed.
+   */
+  Ptr<Application> InstallPriv (Ptr<Node> node) const;
+
+  ObjectFactory m_factory; //!< Object factory.
+};
+
+} // namespace ns3
+
+#endif /* AQUA_SIM_APP_HELPER_H */

--- a/model/aqua-sim-application.cc
+++ b/model/aqua-sim-application.cc
@@ -1,0 +1,363 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+//
+// Based on OnOffAppplication.
+// Sends out the packets to a randomly chosen destination, based on the given list of receive sockets
+//
+
+#include "ns3/log.h"
+#include "ns3/address.h"
+#include "ns3/inet-socket-address.h"
+#include "ns3/inet6-socket-address.h"
+#include "ns3/packet-socket-address.h"
+#include "ns3/node.h"
+#include "ns3/nstime.h"
+#include "ns3/data-rate.h"
+#include "ns3/random-variable-stream.h"
+#include "ns3/socket.h"
+#include "ns3/simulator.h"
+#include "ns3/socket-factory.h"
+#include "ns3/packet.h"
+#include "ns3/uinteger.h"
+#include "ns3/trace-source-accessor.h"
+#include "aqua-sim-application.h"
+#include "ns3/udp-socket-factory.h"
+#include "ns3/string.h"
+#include "ns3/pointer.h"
+
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("AquaSimApplication");
+
+NS_OBJECT_ENSURE_REGISTERED (AquaSimApplication);
+
+TypeId
+AquaSimApplication::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::AquaSimApplication")
+    .SetParent<Application> ()
+    .SetGroupName("Applications")
+    .AddConstructor<AquaSimApplication> ()
+    .AddAttribute ("DataRate", "The data rate in on state.",
+                   DataRateValue (DataRate ("500kb/s")),
+                   MakeDataRateAccessor (&AquaSimApplication::m_cbrRate),
+                   MakeDataRateChecker ())
+    .AddAttribute ("PacketSize", "The size of packets sent in on state",
+                   UintegerValue (512),
+                   MakeUintegerAccessor (&AquaSimApplication::m_pktSize),
+                   MakeUintegerChecker<uint32_t> (1))
+//    .AddAttribute ("RemoteDestinationList", "List of the destination addresses",
+//                   AddressValue (),
+//                   MakeAddressAccessor (&AquaSimApplication::m_peer_list),
+//                   MakeAddressChecker ())
+
+    .AddAttribute ("NumberOfDestinations", "Number of destinations",
+    			   UintegerValue (),
+				   MakeUintegerAccessor (&AquaSimApplication::m_numberOfDestinations),
+				   MakeUintegerChecker<uint32_t> ())
+
+    .AddAttribute ("OnTime", "A RandomVariableStream used to pick the duration of the 'On' state.",
+                   StringValue ("ns3::ConstantRandomVariable[Constant=1.0]"),
+                   MakePointerAccessor (&AquaSimApplication::m_onTime),
+                   MakePointerChecker <RandomVariableStream>())
+    .AddAttribute ("OffTime", "A RandomVariableStream used to pick the duration of the 'Off' state.",
+                   StringValue ("ns3::ConstantRandomVariable[Constant=1.0]"),
+                   MakePointerAccessor (&AquaSimApplication::m_offTime),
+                   MakePointerChecker <RandomVariableStream>())
+    .AddAttribute ("MaxBytes", 
+                   "The total number of bytes to send. Once these bytes are sent, "
+                   "no packet is sent again, even in on state. The value zero means "
+                   "that there is no limit.",
+                   UintegerValue (0),
+                   MakeUintegerAccessor (&AquaSimApplication::m_maxBytes),
+                   MakeUintegerChecker<uint64_t> ())
+    .AddAttribute ("Protocol", "The type of protocol to use. This should be "
+                   "a subclass of ns3::SocketFactory",
+                   TypeIdValue (UdpSocketFactory::GetTypeId ()),
+                   MakeTypeIdAccessor (&AquaSimApplication::m_tid),
+                   // This should check for SocketFactory as a parent
+                   MakeTypeIdChecker ())
+    .AddTraceSource ("Tx", "A new packet is created and is sent",
+                     MakeTraceSourceAccessor (&AquaSimApplication::m_txTrace),
+                     "ns3::Packet::TracedCallback")
+  ;
+  return tid;
+}
+
+
+AquaSimApplication::AquaSimApplication ()
+  : m_socket_init (false),
+    m_connected (false),
+    m_residualBits (0),
+    m_lastStartTime (Seconds (0)),
+    m_totBytes (0)
+{
+  NS_LOG_FUNCTION (this);
+  m_rand = CreateObject<UniformRandomVariable> ();
+}
+
+AquaSimApplication::~AquaSimApplication()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+void 
+AquaSimApplication::SetMaxBytes (uint64_t maxBytes)
+{
+  NS_LOG_FUNCTION (this << maxBytes);
+  m_maxBytes = maxBytes;
+}
+
+Ptr<Socket>
+AquaSimApplication::GetSocket (void) const
+{
+  NS_LOG_FUNCTION (this);
+  // Return the first socket for now // TODO: fix it
+  return m_socket_list.at(0);
+}
+
+int64_t 
+AquaSimApplication::AssignStreams (int64_t stream)
+{
+  NS_LOG_FUNCTION (this << stream);
+  m_onTime->SetStream (stream);
+  m_offTime->SetStream (stream + 1);
+  return 2;
+}
+
+void
+AquaSimApplication::DoDispose (void)
+{
+  NS_LOG_FUNCTION (this);
+
+  // TODO: dispose the vectors as well
+//  m_socket_dst_map = 0;
+  // chain up
+  Application::DoDispose ();
+}
+
+// Application Methods
+void AquaSimApplication::StartApplication () // Called at time specified by Start
+{
+  NS_LOG_FUNCTION (this);
+
+  // Create the socket if not already
+  if (!m_socket_init)
+    {
+	  m_socket_init = true;
+	  memset (m_address, 0, 2);
+//	  address = Address (11, m_address, 11);
+//	  address.CopyTo(m_address);
+
+	  // Create a socket for each destination in list
+	  for (uint16_t i = 1; i <= m_numberOfDestinations; i++)
+	  {
+
+		  if (i != (GetNode()->GetId() + 1))
+		  {
+			  Ptr<Socket> socket = Socket::CreateSocket (GetNode (), m_tid);
+
+			  m_address[0] = (i >> 8) & 0xff;
+			  m_address[1] = (i >> 0) & 0xff;
+
+			  Address address = Address (2, m_address, 2);
+
+			  PacketSocketAddress packet_socket;
+			  packet_socket.SetAllDevices();
+			  packet_socket.SetPhysicalAddress(address);
+			  packet_socket.SetProtocol(0);
+
+		      if (Inet6SocketAddress::IsMatchingType (Address(packet_socket)))
+		        {
+		          if (socket->Bind6 () == -1)
+		            {
+		              NS_FATAL_ERROR ("Failed to bind socket");
+		            }
+		        }
+		      else if (InetSocketAddress::IsMatchingType (Address(packet_socket)) ||
+		               PacketSocketAddress::IsMatchingType (Address(packet_socket)))
+		        {
+		          if (socket->Bind () == -1)
+		            {
+		        	  std::cout << "Failed to bind socket\n";
+		              NS_FATAL_ERROR ("Failed to bind socket");
+		            }
+		        }
+		      socket->Connect (Address(packet_socket));
+		      socket->SetAllowBroadcast (true);
+		      socket->ShutdownRecv ();
+
+		      /// ???
+		      socket->SetConnectCallback (
+		        MakeCallback (&AquaSimApplication::ConnectionSucceeded, this),
+		        MakeCallback (&AquaSimApplication::ConnectionFailed, this));
+		      /// ???
+
+		      // Save socket to list
+		      m_socket_list.push_back(socket);
+		      // Save address to list
+		      m_peer_list.push_back(Address(packet_socket));
+		  }
+	  }
+    }
+
+  m_cbrRateFailSafe = m_cbrRate;
+
+  // Insure no pending event
+  CancelEvents ();
+  // If we are not yet connected, there is nothing to do here
+  // The ConnectionComplete upcall will start timers at that time
+  //if (!m_connected) return;
+  ScheduleStartEvent ();
+}
+
+void AquaSimApplication::StopApplication () // Called at time specified by Stop
+{
+  NS_LOG_FUNCTION (this);
+
+  CancelEvents ();
+  if(m_socket_init != 0)
+    {
+	  for (auto it = m_socket_list.begin(); it != m_socket_list.end(); ++it)
+	  {
+		  (*it)->Close();
+	  }
+    }
+  else
+    {
+      NS_LOG_WARN ("AquaSimApplication found null socket to close in StopApplication");
+    }
+}
+
+void AquaSimApplication::CancelEvents ()
+{
+  NS_LOG_FUNCTION (this);
+
+  if (m_sendEvent.IsRunning () && m_cbrRateFailSafe == m_cbrRate )
+    { // Cancel the pending send packet event
+      // Calculate residual bits since last packet sent
+      Time delta (Simulator::Now () - m_lastStartTime);
+      int64x64_t bits = delta.To (Time::S) * m_cbrRate.GetBitRate ();
+      m_residualBits += bits.GetHigh ();
+    }
+  m_cbrRateFailSafe = m_cbrRate;
+  Simulator::Cancel (m_sendEvent);
+  Simulator::Cancel (m_startStopEvent);
+}
+
+// Event handlers
+void AquaSimApplication::StartSending ()
+{
+  NS_LOG_FUNCTION (this);
+  m_lastStartTime = Simulator::Now ();
+  ScheduleNextTx ();  // Schedule the send packet event
+  ScheduleStopEvent ();
+}
+
+void AquaSimApplication::StopSending ()
+{
+  NS_LOG_FUNCTION (this);
+  CancelEvents ();
+
+  ScheduleStartEvent ();
+}
+
+// Private helpers
+void AquaSimApplication::ScheduleNextTx ()
+{
+  NS_LOG_FUNCTION (this);
+
+  if (m_maxBytes == 0 || m_totBytes < m_maxBytes)
+    {
+      uint32_t bits = m_pktSize * 8 - m_residualBits;
+      NS_LOG_LOGIC ("bits = " << bits);
+      Time nextTime (Seconds (bits /
+                              static_cast<double>(m_cbrRate.GetBitRate ()))); // Time till next packet
+      NS_LOG_LOGIC ("nextTime = " << nextTime);
+      m_sendEvent = Simulator::Schedule (nextTime,
+                                         &AquaSimApplication::SendPacket, this);
+    }
+  else
+    { // All done, cancel any pending events
+      StopApplication ();
+    }
+}
+
+void AquaSimApplication::ScheduleStartEvent ()
+{  // Schedules the event to start sending data (switch to the "On" state)
+  NS_LOG_FUNCTION (this);
+
+  Time offInterval = Seconds (m_offTime->GetValue ());
+  NS_LOG_LOGIC ("start at " << offInterval);
+  m_startStopEvent = Simulator::Schedule (offInterval, &AquaSimApplication::StartSending, this);
+}
+
+void AquaSimApplication::ScheduleStopEvent ()
+{  // Schedules the event to stop sending data (switch to "Off" state)
+  NS_LOG_FUNCTION (this);
+
+  Time onInterval = Seconds (m_onTime->GetValue ());
+  NS_LOG_LOGIC ("stop at " << onInterval);
+  m_startStopEvent = Simulator::Schedule (onInterval, &AquaSimApplication::StopSending, this);
+}
+
+
+void AquaSimApplication::SendPacket ()
+{
+  NS_LOG_FUNCTION (this);
+
+  NS_ASSERT (m_sendEvent.IsExpired ());
+  Ptr<Packet> packet = Create<Packet> (m_pktSize);
+  m_txTrace (packet);
+
+  // Randomly select a socket, and send packet
+  int index = m_rand->GetValue(0, m_numberOfDestinations - 1);
+
+  m_socket_list.at(index)->Send (packet);
+
+//  std::cout << "ADDRESS to SEND: " << m_peer_list.at(index) << "\n";
+
+  m_totBytes += m_pktSize;
+  if (InetSocketAddress::IsMatchingType (m_peer_list.at(index)))
+    {
+//	  std::cout << "At time " << Simulator::Now ().GetSeconds ()
+//                           << "s on-off application sent "
+//                           <<  packet->GetSize () << " bytes to "
+//                           << InetSocketAddress::ConvertFrom(m_peer_list.at(index)).GetIpv4 ()
+//                           << " port " << InetSocketAddress::ConvertFrom (m_peer_list.at(index)).GetPort ()
+//                           << " total Tx " << m_totBytes << " bytes\n";
+
+      NS_LOG_INFO ("At time " << Simulator::Now ().GetSeconds ()
+                   << "s on-off application sent "
+                   <<  packet->GetSize () << " bytes to "
+                   << InetSocketAddress::ConvertFrom(m_peer_list.at(index)).GetIpv4 ()
+                   << " port " << InetSocketAddress::ConvertFrom (m_peer_list.at(index)).GetPort ()
+                   << " total Tx " << m_totBytes << " bytes");
+    }
+  else if (Inet6SocketAddress::IsMatchingType (m_peer_list.at(index)))
+    {
+      NS_LOG_INFO ("At time " << Simulator::Now ().GetSeconds ()
+                   << "s on-off application sent "
+                   <<  packet->GetSize () << " bytes to "
+                   << Inet6SocketAddress::ConvertFrom(m_peer_list.at(index)).GetIpv6 ()
+                   << " port " << Inet6SocketAddress::ConvertFrom (m_peer_list.at(index)).GetPort ()
+                   << " total Tx " << m_totBytes << " bytes");
+    }
+  m_lastStartTime = Simulator::Now ();
+  m_residualBits = 0;
+  ScheduleNextTx ();
+}
+
+
+void AquaSimApplication::ConnectionSucceeded (Ptr<Socket> socket)
+{
+  NS_LOG_FUNCTION (this << socket);
+  m_connected = true;
+}
+
+void AquaSimApplication::ConnectionFailed (Ptr<Socket> socket)
+{
+  NS_LOG_FUNCTION (this << socket);
+}
+
+} // Namespace ns3

--- a/model/aqua-sim-application.h
+++ b/model/aqua-sim-application.h
@@ -1,0 +1,147 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+//
+// Based on OnOffAppplication.
+// Sends out the packets to a randomly chosen destination, based on the given list of receive sockets
+//
+
+#ifndef AQUA_SIM_APPLICATION_H
+#define AQUA_SIM_APPLICATION_H
+
+#include "ns3/address.h"
+#include "ns3/application.h"
+#include "ns3/event-id.h"
+#include "ns3/ptr.h"
+#include "ns3/data-rate.h"
+#include "ns3/traced-callback.h"
+#include "ns3/random-variable-stream.h"
+
+namespace ns3 {
+
+class Address;
+class RandomVariableStream;
+class Socket;
+
+
+class AquaSimApplication : public Application
+{
+public:
+  /**
+   * \brief Get the type ID.
+   * \return the object TypeId
+   */
+  static TypeId GetTypeId (void);
+
+  AquaSimApplication ();
+
+  virtual ~AquaSimApplication();
+
+  /**
+   * \brief Set the total number of bytes to send.
+   *
+   * Once these bytes are sent, no packet is sent again, even in on state.
+   * The value zero means that there is no limit.
+   *
+   * \param maxBytes the total number of bytes to send
+   */
+  void SetMaxBytes (uint64_t maxBytes);
+
+  /**
+   * \brief Return a pointer to associated socket.
+   * \return pointer to associated socket
+   */
+  Ptr<Socket> GetSocket (void) const;
+
+ /**
+  * \brief Assign a fixed random variable stream number to the random variables
+  * used by this model.
+  *
+  * \param stream first stream index to use
+  * \return the number of stream indices assigned by this model
+  */
+  int64_t AssignStreams (int64_t stream);
+
+protected:
+  virtual void DoDispose (void);
+private:
+  // inherited from Application base class.
+  virtual void StartApplication (void);    // Called at time specified by Start
+  virtual void StopApplication (void);     // Called at time specified by Stop
+
+  //helpers
+  /**
+   * \brief Cancel all pending events.
+   */
+  void CancelEvents ();
+
+  // Event handlers
+  /**
+   * \brief Start an On period
+   */
+  void StartSending ();
+  /**
+   * \brief Start an Off period
+   */
+  void StopSending ();
+  /**
+   * \brief Send a packet
+   */
+  void SendPacket ();
+
+  // Flag to initialize socket-dst map
+  bool m_socket_init;
+  // List of sockets for each destination
+  std::vector<Ptr<Socket>> m_socket_list;
+  // List of destination addresses
+  std::vector<Address> m_peer_list;
+
+  bool            m_connected;    //!< True if connected
+  Ptr<RandomVariableStream>  m_onTime;       //!< rng for On Time
+  Ptr<RandomVariableStream>  m_offTime;      //!< rng for Off Time
+  DataRate        m_cbrRate;      //!< Rate that data is generated
+  DataRate        m_cbrRateFailSafe;      //!< Rate that data is generated (check copy)
+  uint32_t        m_pktSize;      //!< Size of packets
+  uint32_t        m_residualBits; //!< Number of generated, but not sent, bits
+  Time            m_lastStartTime; //!< Time last packet sent
+  uint64_t        m_maxBytes;     //!< Limit total number of bytes sent
+  uint64_t        m_totBytes;     //!< Total bytes sent so far
+  EventId         m_startStopEvent;     //!< Event id for next start or stop event
+  EventId         m_sendEvent;    //!< Event id of pending "send packet" event
+  TypeId          m_tid;          //!< Type of the socket used
+
+  // For random destination selection
+  Ptr<UniformRandomVariable> m_rand;
+  uint32_t m_numberOfDestinations = 0;
+
+  uint8_t m_address[2]; //!< address value
+
+  /// Traced Callback: transmitted packets.
+  TracedCallback<Ptr<const Packet> > m_txTrace;
+
+private:
+  /**
+   * \brief Schedule the next packet transmission
+   */
+  void ScheduleNextTx ();
+  /**
+   * \brief Schedule the next On period start
+   */
+  void ScheduleStartEvent ();
+  /**
+   * \brief Schedule the next Off period start
+   */
+  void ScheduleStopEvent ();
+  /**
+   * \brief Handle a Connection Succeed event
+   * \param socket the connected socket
+   */
+  void ConnectionSucceeded (Ptr<Socket> socket);
+  /**
+   * \brief Handle a Connection Failed event
+   * \param socket the not connected socket
+   */
+  void ConnectionFailed (Ptr<Socket> socket);
+};
+
+} // namespace ns3
+
+#endif /* AQUA_SIM_APPLICATION_H */

--- a/model/aqua-sim-header-mac.cc
+++ b/model/aqua-sim-header-mac.cc
@@ -868,3 +868,491 @@ LocalizationHeader::GetInstanceTypeId(void) const
 {
   return GetTypeId();
 }
+
+/*
+ * MacLibraHeader
+ */
+MacLibraHeader::MacLibraHeader()
+{
+}
+
+MacLibraHeader::~MacLibraHeader()
+{
+}
+
+TypeId
+MacLibraHeader::GetTypeId()
+{
+  static TypeId tid = TypeId("ns3::MacLibraHeader")
+    .SetParent<Header>()
+    .AddConstructor<MacLibraHeader>()
+  ;
+  return tid;
+}
+
+uint32_t
+MacLibraHeader::GetSerializedSize(void) const
+{
+	// DATA
+	if (m_ptype == 0)
+	{
+		// ptype + header_id + hop_count + reward + ... [in bytes]
+		return 45;
+	}
+	// RREQ / RREP
+	if ((m_ptype == 1) || (m_ptype == 2))
+	{
+		return 1 + 4 + 1 + 2 + 2 + 16;	// Add tx/rx parameters
+	}
+	// ACK
+	if (m_ptype == 3)
+	{
+		return 1 + 4 + 4 + 4 + 4 + 16;	// Add tx/rx parameters
+	}
+	// INIT
+	if (m_ptype == 4)
+	{
+		return 1 + 4 + 4 + 16;	// Add tx/rx parameters
+	}
+	// RTS
+	if (m_ptype == 5)
+	{
+		return 1 + 4 + 4 + 16;	// Add tx/rx parameters
+	}
+	// CTS
+	if (m_ptype == 6)
+	{
+		return 1 + 4 + 4 + 16;	// Add tx/rx parameters
+	}
+	// Direct Reward Message
+	if (m_ptype == 7)
+	{
+		return 29 + 4;
+	}
+
+	// This should not happen
+	return 0;
+}
+
+void
+MacLibraHeader::Serialize (Buffer::Iterator start) const
+{
+  Buffer::Iterator i = start;
+  if (m_ptype == 0)
+  {
+	  i.WriteU8 ((uint8_t)(m_ptype));
+	  i.WriteU32 ((uint32_t)(m_header_id));
+	  i.WriteU8 ((uint8_t)(m_hop_count));
+	  i.WriteU32 ((uint32_t)(m_reward));
+	  i.WriteU16 ((uint16_t)(m_sender_addr.GetAsInt()));
+	  i.WriteU16 ((uint16_t)(m_src_addr.GetAsInt()));
+	  i.WriteU16 ((uint16_t)(m_dst_addr.GetAsInt()));
+	  i.WriteU32 ((uint32_t)(m_direct_distance));
+	  // Add tx/rx parameters
+	  i.WriteU64 ((uint64_t)(m_tx_power));
+	  i.WriteU64 ((uint64_t)(m_rx_power));
+	  i.WriteU32 ((uint32_t)(m_next_hop_distance));
+	  i.WriteU32 ((uint32_t)(m_optimal_distance));
+	  i.WriteU8 ((uint8_t)(m_max_hops_number));
+  }
+  if (m_ptype == 1)
+  {
+	  i.WriteU8 ((uint8_t)(m_ptype));
+	  i.WriteU32 ((uint32_t)(m_header_id));
+	  i.WriteU8 ((uint8_t)(m_hop_count));
+	  i.WriteU16 ((uint16_t)(m_src_addr.GetAsInt()));
+	  i.WriteU16 ((uint16_t)(m_dst_addr.GetAsInt()));
+	  // Add tx/rx parameters
+	  i.WriteU64 ((uint64_t)(m_tx_power));
+	  i.WriteU64 ((uint64_t)(m_rx_power));
+  }
+  if (m_ptype == 2)
+  {
+	  i.WriteU8 ((uint8_t)(m_ptype));
+	  i.WriteU32 ((uint32_t)(m_header_id));
+	  i.WriteU8 ((uint8_t)(m_hop_count));
+	  i.WriteU16 ((uint16_t)(m_src_addr.GetAsInt()));
+	  i.WriteU16 ((uint16_t)(m_dst_addr.GetAsInt()));
+	  // Add tx/rx parameters
+	  i.WriteU64 ((uint64_t)(m_tx_power));
+	  i.WriteU64 ((uint64_t)(m_rx_power));
+  }
+  if (m_ptype == 3)
+  {
+	  i.WriteU8 ((uint8_t)(m_ptype));
+	  i.WriteU32 ((uint32_t)(m_header_id));
+	  i.WriteU8 ((uint32_t)(m_reward));
+	  i.WriteU32 ((uint32_t)(m_ack_message_id));
+	  i.WriteU16 ((uint16_t)(m_src_addr.GetAsInt()));
+	  i.WriteU16 ((uint16_t)(m_dst_addr.GetAsInt()));
+	  // Add tx/rx parameters
+	  i.WriteU64 ((uint64_t)(m_tx_power));
+	  i.WriteU64 ((uint64_t)(m_rx_power));
+  }
+  // 4 - INIT
+  if (m_ptype == 4)
+  {
+	  i.WriteU8 ((uint8_t)(m_ptype));
+	  i.WriteU32 ((uint32_t)(m_header_id));
+	  i.WriteU16 ((uint16_t)(m_src_addr.GetAsInt()));
+	  i.WriteU16 ((uint16_t)(m_dst_addr.GetAsInt()));
+	  // Add tx/rx parameters
+	  i.WriteU64 ((uint64_t)(m_tx_power));
+	  i.WriteU64 ((uint64_t)(m_rx_power));
+  }
+  // 5 - RTS
+  if (m_ptype == 5)
+  {
+	  i.WriteU8 ((uint8_t)(m_ptype));
+	  i.WriteU32 ((uint32_t)(m_header_id));
+	  i.WriteU16 ((uint16_t)(m_src_addr.GetAsInt()));
+	  i.WriteU16 ((uint16_t)(m_dst_addr.GetAsInt()));
+	  // Add tx/rx parameters
+	  i.WriteU64 ((uint64_t)(m_tx_power));
+	  i.WriteU64 ((uint64_t)(m_rx_power));
+  }
+  // 6 - CTS
+  if (m_ptype == 6)
+  {
+	  i.WriteU8 ((uint8_t)(m_ptype));
+	  i.WriteU32 ((uint32_t)(m_header_id));
+	  i.WriteU16 ((uint16_t)(m_src_addr.GetAsInt()));
+	  i.WriteU16 ((uint16_t)(m_dst_addr.GetAsInt()));
+	  // Add tx/rx parameters
+	  i.WriteU64 ((uint64_t)(m_tx_power));
+	  i.WriteU64 ((uint64_t)(m_rx_power));
+  }
+  // 7 - Direct Reward Message
+  if (m_ptype == 7)
+  {
+	  i.WriteU8 ((uint8_t)(m_ptype));
+	  i.WriteU32 ((uint32_t)(m_header_id));
+	  i.WriteU16 ((uint16_t)(m_src_addr.GetAsInt()));
+	  i.WriteU16 ((uint16_t)(m_dst_addr.GetAsInt()));
+	  i.WriteU32 ((uint32_t)(m_reward));
+	  // Add tx/rx parameters
+	  i.WriteU64 ((uint64_t)(m_tx_power));
+	  i.WriteU64 ((uint64_t)(m_rx_power));
+	  i.WriteU32 ((uint32_t)(m_next_hop_distance));
+  }
+
+}
+
+uint32_t
+MacLibraHeader::Deserialize (Buffer::Iterator start)
+{
+  Buffer::Iterator i = start;
+  m_ptype = i.ReadU8();
+//  std::cout << "DESERIALIZED:" << m_ptype << "\n";
+
+  // DATA frame format: | PTYPE | ID | HOP_COUNT | REWARD_VALUE | SENDER_ADDR | SRC_ADDR | DST_ADDR | DIRECT_DISTANCE | TX_POWER | RX_POWER |
+  if (m_ptype == 0)
+  {
+//	  m_ptype = i.ReadU8();
+	  m_header_id = i.ReadU32();
+	  m_hop_count = i.ReadU8();
+	  m_reward = i.ReadU32();
+	  m_sender_addr = (AquaSimAddress) i.ReadU16();
+	  m_src_addr = (AquaSimAddress) i.ReadU16();
+	  m_dst_addr = (AquaSimAddress) i.ReadU16();
+	  m_direct_distance = i.ReadU32();
+	  // Get tx/rx parameters
+	  m_tx_power = i.ReadU64();
+	  m_rx_power = i.ReadU64();
+	  m_next_hop_distance = i.ReadU32();
+	  // Carry optimal_distance value
+	  m_optimal_distance = i.ReadU32();
+	  m_max_hops_number = i.ReadU8();
+  }
+  if (m_ptype == 1)
+  {
+//	  m_ptype = i.ReadU16();
+	  m_header_id = i.ReadU32();
+	  m_hop_count = i.ReadU8();
+	  m_src_addr = (AquaSimAddress) i.ReadU16();
+	  m_dst_addr = (AquaSimAddress) i.ReadU16();
+	  // Get tx/rx parameters
+	  m_tx_power = i.ReadU64();
+	  m_rx_power = i.ReadU64();
+  }
+  if (m_ptype == 2)
+  {
+//	  m_ptype = i.ReadU8();
+	  m_header_id = i.ReadU32();
+	  m_hop_count = i.ReadU8();
+	  m_src_addr = (AquaSimAddress) i.ReadU16();
+	  m_dst_addr = (AquaSimAddress) i.ReadU16();
+	  // Get tx/rx parameters
+	  m_tx_power = i.ReadU64();
+	  m_rx_power = i.ReadU64();
+  }
+  if (m_ptype == 3)
+  {
+//	  m_ptype = i.ReadU8();
+	  m_header_id = i.ReadU32();
+	  m_reward = i.ReadU32();
+	  m_ack_message_id = i.ReadU32();
+	  m_src_addr = (AquaSimAddress) i.ReadU16();
+	  m_dst_addr = (AquaSimAddress) i.ReadU16();
+	  // Get tx/rx parameters
+	  m_tx_power = i.ReadU64();
+	  m_rx_power = i.ReadU64();
+  }
+  // 4 - INIT
+  if (m_ptype == 4)
+  {
+//	  m_ptype = i.ReadU8();
+	  m_header_id = i.ReadU32();
+//	  m_reward = i.ReadU32();
+//	  m_ack_message_id = i.ReadU32();
+	  m_src_addr = (AquaSimAddress) i.ReadU16();
+	  m_dst_addr = (AquaSimAddress) i.ReadU16();
+	  // Get tx/rx parameters
+	  m_tx_power = i.ReadU64();
+	  m_rx_power = i.ReadU64();
+  }
+  // 5 - RTS
+  if (m_ptype == 5)
+  {
+//	  m_ptype = i.ReadU8();
+	  m_header_id = i.ReadU32();
+//	  m_reward = i.ReadU32();
+//	  m_ack_message_id = i.ReadU32();
+	  m_src_addr = (AquaSimAddress) i.ReadU16();
+	  m_dst_addr = (AquaSimAddress) i.ReadU16();
+	  // Get tx/rx parameters
+	  m_tx_power = i.ReadU64();
+	  m_rx_power = i.ReadU64();
+  }
+  // 6 - CTS
+  if (m_ptype == 6)
+  {
+//	  m_ptype = i.ReadU8();
+	  m_header_id = i.ReadU32();
+//	  m_reward = i.ReadU32();
+//	  m_ack_message_id = i.ReadU32();
+	  m_src_addr = (AquaSimAddress) i.ReadU16();
+	  m_dst_addr = (AquaSimAddress) i.ReadU16();
+	  // Get tx/rx parameters
+	  m_tx_power = i.ReadU64();
+	  m_rx_power = i.ReadU64();
+  }
+  // 7 - Direct Reward Message
+  if (m_ptype == 7)
+  {
+//	  m_ptype = i.ReadU8();
+	  m_header_id = i.ReadU32();
+//	  m_reward = i.ReadU32();
+//	  m_ack_message_id = i.ReadU32();
+	  m_src_addr = (AquaSimAddress) i.ReadU16();
+	  m_dst_addr = (AquaSimAddress) i.ReadU16();
+	  m_reward = i.ReadU32();
+	  // Get tx/rx parameters
+	  m_tx_power = i.ReadU64();
+	  m_rx_power = i.ReadU64();
+	  // Carry next_hop_distance
+	  m_next_hop_distance = i.ReadU32();
+  }
+
+  return GetSerializedSize();
+}
+
+void
+MacLibraHeader::Print (std::ostream &os) const
+{
+  os << "MacRouting Header: ";
+
+  if (m_ptype == 0)
+  {
+	  os << "PType=" << int(m_ptype) << " ";
+	  os << "Header_id=" << m_header_id << " ";
+	  os << "Hop_count=" << int(m_hop_count) << " ";
+	  os << "Reward=" << m_reward / m_multiplier_32 << " ";
+	  os << "Sender_addr=" << m_sender_addr << " ";
+	  os << "Src_addr=" << m_src_addr << " ";
+	  os << "Dst_addr=" << m_dst_addr << " ";
+	  os << "Direct_distance=" << m_direct_distance / m_multiplier_32 << " ";
+	  os << "Tx_power=" << m_tx_power / m_multiplier_64 << " ";
+	  os << "Rx_power=" << m_rx_power / m_multiplier_64 << " ";
+	  os << "Next_hop_distance=" << m_next_hop_distance / m_multiplier_32 << " ";
+	  os << "Optimal_distance=" << m_optimal_distance / m_multiplier_32 << " ";
+	  os << "Max_hops_number=" << int(m_max_hops_number) << " ";
+  }
+
+  if (m_ptype == 7)
+  {
+	  os << "PType=" << int(m_ptype) << " ";
+	  os << "Header_id=" << m_header_id << " ";
+	  os << "Src_addr=" << m_src_addr << " ";
+	  os << "Dst_addr=" << m_dst_addr << " ";
+	  os << "Reward=" << m_reward / m_multiplier_32 << " ";
+	  os << "Tx_power=" << m_tx_power / m_multiplier_64 << " ";
+	  os << "Rx_power=" << m_rx_power / m_multiplier_64 << " ";
+	  os << "Next_hop_distance=" << m_next_hop_distance / m_multiplier_32 << " ";
+  }
+
+  os << "\n";
+}
+
+TypeId
+MacLibraHeader::GetInstanceTypeId(void) const
+{
+  return GetTypeId();
+}
+
+void
+MacLibraHeader::SetPType(uint8_t ptype)
+{
+	m_ptype = ptype;
+}
+
+int
+MacLibraHeader::GetPType()
+{
+	return m_ptype;
+}
+
+void
+MacLibraHeader::SetId(uint32_t header_id)
+{
+	m_header_id = header_id;
+}
+
+void
+MacLibraHeader::SetHopCount(uint8_t hop_count)
+{
+	m_hop_count = hop_count;
+}
+
+void
+MacLibraHeader::SetSrcAddr(AquaSimAddress src_addr)
+{
+	m_src_addr = src_addr;
+}
+
+void
+MacLibraHeader::SetDstAddr(AquaSimAddress dst_addr)
+{
+	m_dst_addr = dst_addr;
+}
+
+void
+MacLibraHeader::SetSenderAddr(AquaSimAddress sender_addr)
+{
+	m_sender_addr = sender_addr;
+}
+
+AquaSimAddress
+MacLibraHeader::GetSrcAddr()
+{
+	return m_src_addr;
+}
+
+AquaSimAddress
+MacLibraHeader::GetDstAddr()
+{
+	return m_dst_addr;
+}
+
+AquaSimAddress
+MacLibraHeader::GetSenderAddr()
+{
+	return m_sender_addr;
+}
+
+void
+MacLibraHeader::SetReward(double reward_value)
+{
+	m_reward = reward_value * m_multiplier_32;
+}
+
+double
+MacLibraHeader::GetReward()
+{
+	return m_reward / m_multiplier_32;
+}
+
+int
+MacLibraHeader::GetHopCount()
+{
+	return m_hop_count;
+}
+
+void
+MacLibraHeader::IncrementHopCount()
+{
+	m_hop_count++;
+}
+
+void
+MacLibraHeader::SetRxPower(double rx_power)
+{
+	m_rx_power = rx_power * m_multiplier_64;
+//	std::cout << "SET RX POWER: " << m_tx_power << "\n";
+}
+
+void
+MacLibraHeader::SetTxPower(double tx_power)
+{
+	m_tx_power = tx_power * m_multiplier_64;
+}
+
+void
+MacLibraHeader::SetDirectDistance(double direct_distance)
+{
+	m_direct_distance = direct_distance * m_multiplier_32;
+}
+
+void
+MacLibraHeader::SetOptimalDistance(double optimal_distance)
+{
+	m_optimal_distance = optimal_distance * m_multiplier_32;
+}
+
+void
+MacLibraHeader::SetNextHopDistance(double next_hop_distance)
+{
+	m_next_hop_distance = next_hop_distance * m_multiplier_32;
+}
+
+void
+MacLibraHeader::SetMaxHopsNumber(uint8_t max_hops_number)
+{
+	m_max_hops_number = max_hops_number;
+}
+
+double
+MacLibraHeader::GetRxPower()
+{
+	return m_rx_power / m_multiplier_64;
+}
+
+double
+MacLibraHeader::GetTxPower()
+{
+	return m_tx_power / m_multiplier_64;
+}
+
+double
+MacLibraHeader::GetDirectDistance()
+{
+	return m_direct_distance / m_multiplier_32;
+}
+
+double
+MacLibraHeader::GetOptimalDistance()
+{
+	return m_optimal_distance / m_multiplier_32;
+}
+
+double
+MacLibraHeader::GetNextHopDistance()
+{
+	return m_next_hop_distance / m_multiplier_32;
+}
+
+uint8_t
+MacLibraHeader::GetMaxHopsNumber()
+{
+	return m_max_hops_number;
+}

--- a/model/aqua-sim-header-mac.h
+++ b/model/aqua-sim-header-mac.h
@@ -47,7 +47,8 @@ public:
     UWPTYPE_LOC,
     UWPTYPE_SYNC,
     UWPTYPE_SYNC_BEACON,
-    UWPTYPE_NDN };
+    UWPTYPE_NDN,
+    UWPTYPE_MAC_LIBRA}; // Add mac_libra mac type
 
   MacHeader();
   static TypeId GetTypeId(void);
@@ -348,6 +349,98 @@ private:
   Vector m_nodePosition;
   double m_confidence;
 };  // class LocalizationHeader
+
+/**
+ * \brief mac-libra header
+ */
+class MacLibraHeader : public Header
+{
+public:
+	MacLibraHeader();
+  virtual ~MacLibraHeader();
+  static TypeId GetTypeId(void);
+
+  void SetPType(uint8_t m_ptype);
+  int GetPType();
+  void SetId(uint32_t m_header_id);
+  void SetHopCount(uint8_t m_hop_count);
+  void IncrementHopCount();
+
+  void SetSrcAddr (AquaSimAddress src_addr);
+  void SetDstAddr (AquaSimAddress dst_addr);
+  void SetSenderAddr (AquaSimAddress sender_addr);
+
+  AquaSimAddress GetSrcAddr ();
+  AquaSimAddress GetDstAddr ();
+  AquaSimAddress GetSenderAddr ();
+
+  void SetReward (double reward_value);
+  double GetReward ();
+
+  int GetHopCount ();
+
+  void SetRxPower (double rx_power);
+  void SetTxPower (double tx_power);
+  void SetDirectDistance (double direct_distance);
+  void SetNextHopDistance (double next_hop_distance);
+  void SetOptimalDistance (double m_optimal_distance);
+  void SetMaxHopsNumber (uint8_t m_max_hops_number);
+
+  double GetRxPower ();
+  double GetTxPower ();
+  double GetDirectDistance ();
+  double GetNextHopDistance ();
+  double GetOptimalDistance ();
+  uint8_t GetMaxHopsNumber ();
+
+  //inherited methods
+  virtual uint32_t GetSerializedSize(void) const;
+  virtual void Serialize (Buffer::Iterator start) const;
+  virtual uint32_t Deserialize (Buffer::Iterator start);
+  virtual void Print (std::ostream &os) const;
+  virtual TypeId GetInstanceTypeId(void) const;
+
+private:
+  // Packet type: 0 - data_packet, 1 - RREQ, 2 - RREP, 3 - ACK, 4 - INIT, 5 - RTS, 6 - CTS, 7 - DIRECT_REWARD
+  uint8_t m_ptype;
+  // Unique header ID
+  uint32_t m_header_id;
+  // Hop count
+  uint8_t m_hop_count = 0;
+  // Source address
+  AquaSimAddress m_src_addr;
+  // Destination address
+  AquaSimAddress m_dst_addr;
+  // Sender address to send back the reward to
+  AquaSimAddress m_sender_addr;
+  // Reward value
+  uint32_t m_reward = 0;
+  // Message ID the ACK is replying to
+  uint32_t m_ack_message_id = 0;
+
+  // Tx power for sending frame
+  uint64_t m_tx_power;
+
+  // Rx power for receiving frame
+  uint64_t m_rx_power = 0;
+
+  // Direct distance from source to destination
+  uint32_t m_direct_distance = 0;
+
+  // Next hop distance, needed for the propagation model
+  uint32_t m_next_hop_distance = 0;
+
+  // Optimal distance, calculated by the source
+  uint32_t m_optimal_distance = 0;
+
+  // Max number of hops, calculated by the source
+  uint8_t m_max_hops_number = 0;
+
+  // Store a multipler to convert from double to uint32/64 and back
+  double m_multiplier_64 = 10000000000000;
+  double m_multiplier_32 = 10000;
+
+};  // class MacLibraHeader
 
 } // namespace ns3
 

--- a/model/aqua-sim-mac-libra.cc
+++ b/model/aqua-sim-mac-libra.cc
@@ -1,0 +1,839 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Author: Dmitrii Dugaev <ddugaev@gradcenter.cuny.edu>
+ */
+
+#include "aqua-sim-mac-libra.h"
+#include "aqua-sim-header.h"
+#include "aqua-sim-header-mac.h"
+#include "aqua-sim-address.h"
+
+#include "ns3/log.h"
+#include "ns3/integer.h"
+#include "ns3/simulator.h"
+
+#include <math.h>
+
+using namespace ns3;
+
+NS_LOG_COMPONENT_DEFINE("AquaSimMacLibra");
+NS_OBJECT_ENSURE_REGISTERED(AquaSimMacLibra);
+
+
+/* ======================================================================
+Adaptive forwarding (routing) MAC for underwater sensor networks
+====================================================================== */
+
+/*
+ * This function calculates the number of relays that minimize the energy consumption
+ *
+ * Arguments
+ * distance:            the distance between the source and destination (km)
+ * packet_size:         the size of the packet (bytes)
+ * link_speed:          the physical layer speed (bps)
+ * p_rx:                the power consumption for receiving and processing (watts)
+ * p_tx_max:            the maximum transmission power (watts)
+ *
+ * Return value
+ * n:                   the optimal number of relays
+ */
+
+//int AquaSimMacLibra::CalculateHopCount(double distance, int packet_size, int link_speed, double p_rx, double p_tx_max)
+uint8_t
+AquaSimMacLibra::CalculateHopCount(double distance, int packet_size, double p_tx_max)
+{
+  double freq = 25.0; // Frequency, in kHz
+  double k = 2.0; // Spreading factor
+  int link_speed = 10000; // bps
+  double p_rx = 0.82; // Watts
+  double t_rx = packet_size * 8.0 / (link_speed*1.0); // Transmission delay
+  double p_rx_min = 5.4764*pow(10,(-8.0)); // Minimal signal strength for successful reception
+  double C1 = (0.011*pow(freq,2.0)/(1.0+pow(freq,2))+4.4*pow(freq,2.0)/(4100.0+freq)+2.75/100000.0*pow(freq,2.0)+0.0003)*(distance/1000.0);
+  double C2 = p_rx_min*pow(distance,k)*8.0*packet_size/(1.0*link_speed);
+  double C3 = t_rx * p_rx;
+  double Em = 0.0; // The energy consumption with relays
+  double Em_last = 0.0; // A temporary variable to store the previous calculated energy consumption
+  int n = 0, loop_count = 10;
+
+  Em_last = C2*pow(10.0,C1/(n+1.0))/pow((n+1.0),(k-1.0))+n*C3;
+  while (n++ < loop_count) {
+    Em = C2*pow(10.0,C1/(n+1.0))/pow((n+1.0),(k-1.0))+n*C3;
+    if (Em < Em_last) {
+      Em_last = Em;
+    }
+    else {
+      n--;
+      break;
+    }
+  }
+//  std::cout << "OPTIMAL HOP COUNT: " << n << "\n";
+//  std::cout << "DISTANCE: " << distance << "\n";
+  // Fix the number of hops for the experiments
+ return n;
+
+// // Fix the number of hops for the experiments !!!
+// return m_nintermediate_nodes;
+}
+
+
+AquaSimMacLibra::AquaSimMacLibra()
+{
+  m_rand = CreateObject<UniformRandomVariable> ();
+  m_max_range = 150;
+  m_max_tx_power = 20; // Watts
+  m_isInRange = true;
+  m_nintermediate_nodes = 0;
+  // Flag to indicate whether the initial distances are initialized
+  m_distances_initialized = false;
+}
+
+TypeId
+AquaSimMacLibra::GetTypeId()
+{
+  static TypeId tid = TypeId("ns3::AquaSimMacLibra")
+      .SetParent<AquaSimMac>()
+      .AddConstructor<AquaSimMacLibra>()
+      .AddAttribute("max_range", "Maximum transmission range",
+        DoubleValue(150),
+        MakeDoubleAccessor (&AquaSimMacLibra::m_max_range),
+        MakeDoubleChecker<double> ())
+	  .AddAttribute("max_tx_power", "Maximum transmission power",
+		DoubleValue(20),
+		MakeDoubleAccessor (&AquaSimMacLibra::m_max_tx_power),
+		MakeDoubleChecker<double> ())
+	  .AddAttribute("packet_size", "Packet size from upper layers",
+		IntegerValue(50),
+		MakeIntegerAccessor (&AquaSimMacLibra::m_packet_size),
+		MakeIntegerChecker<int> ())
+	// Pass the number of intermediate hops explicitly (for some experiments only !!!)
+	  .AddAttribute("intermediate_nodes", "Number of intermediate nodes for each packet transmission",
+		IntegerValue(0), // 0 - direct transmission to destination
+		MakeIntegerAccessor (&AquaSimMacLibra::m_nintermediate_nodes),
+		MakeIntegerChecker<int> ())
+
+     ;
+  return tid;
+}
+
+int64_t
+AquaSimMacLibra::AssignStreams (int64_t stream)
+{
+  NS_LOG_FUNCTION (this << stream);
+  m_rand->SetStream(stream);
+  return 1;
+}
+
+/*
+this program is used to handle the received packet,
+it should be virtual function, different class may have
+different versions.
+*/
+bool
+AquaSimMacLibra::RecvProcess (Ptr<Packet> pkt)
+{
+  NS_LOG_FUNCTION(this);
+  /*std::cout << "\nBMac @RecvProcess check:\n";
+  pkt->Print(std::cout);
+  std::cout << "\n";*/
+
+  // Calculate initial distances
+  if (!m_distances_initialized)
+  {
+  	InitializeDistances();
+  	m_distances_initialized = true;
+  }
+
+  AquaSimHeader ash;
+  MacHeader mach;
+  MacLibraHeader mac_libra_h;
+
+  pkt->RemoveHeader(ash);
+  pkt->RemoveHeader(mach);
+  pkt->RemoveHeader(mac_libra_h);
+
+	AquaSimAddress dst = mac_libra_h.GetDstAddr();
+	AquaSimAddress sender_addr = mac_libra_h.GetSenderAddr();
+
+	if (ash.GetErrorFlag())
+	{
+		NS_LOG_DEBUG("LibraMac:RecvProcess: received corrupt packet.");
+		pkt=0;
+		return false;
+	}
+
+		NS_LOG_DEBUG("\n-------------------\nPTYPE: " << mac_libra_h.GetPType());
+		NS_LOG_DEBUG("TS: " << Simulator::Now());
+		NS_LOG_DEBUG("SRC: " << mac_libra_h.GetSrcAddr());
+		NS_LOG_DEBUG("DST: " << mac_libra_h.GetDstAddr());
+		NS_LOG_DEBUG("HOP COUNT: " << mac_libra_h.GetHopCount());
+
+
+		// DATA PACKET TYPE
+		////////////////////
+		////////////////////
+
+		// If the DATA packet comes from the network (i.e. PHY), then process it
+		if (mac_libra_h.GetPType() == 0)
+		{
+			// TODO: maybe to include some overhearing here. I.e., update the local distances table from all received packets
+			// The DATA packet must be destined to the node
+			if (dst == AquaSimAddress::ConvertFrom(m_device->GetAddress()))
+			{
+				// If dst_addr is its own, send up
+				// If not, forward packet further
+				double reward = 0;
+				if (mach.GetDA() == AquaSimAddress::ConvertFrom(m_device->GetAddress()))
+				{
+					// The data packet is for this node, send it up
+					pkt->AddHeader(ash);  //leave MacHeader off since sending to upper layers
+//					NS_LOG_DEBUG("SENDING UP HOP COUNT: " << mac_libra_h.GetHopCount());
+					SendUp(pkt);
+
+					// Generate a single direct reward message back to the sender
+					// Set mac_libra_header parameters
+					Ptr<Packet> reward_msg = Create<Packet>();
+					MacLibraHeader reward_h;
+					reward_h.SetPType(7); // 7 - DIRECT REWARD MESSAGE
+					reward_h.SetId(0);
+					reward_h.SetSrcAddr(AquaSimAddress::ConvertFrom(m_device->GetAddress()));
+					reward_h.SetDstAddr(mac_libra_h.GetSrcAddr());
+
+//					std::cout << "REWARD SRC ADDR: " << reward_h.GetSrcAddr() << "\n";
+//					std::cout << "REWARD DST ADDR: " << reward_h.GetDstAddr() << "\n";
+
+					// Set aqua-sim-header parameters for correct handling on Phy layer
+					ash.SetSize(reward_h.GetSerializedSize() + mach.GetSerializedSize());
+					// ash.SetTxTime(Phy()->CalcTxTime(ash.GetSize()) + Seconds(0.0014));
+					ash.SetTxTime(Phy()->CalcTxTime(ash.GetSize()));
+					// ash.SetTxTime(Phy()->CalcTxTime(ash.GetSize()));
+					ash.SetErrorFlag(false);
+					ash.SetDirection(AquaSimHeader::DOWN);
+
+					// Set Tx power for the frame
+//					reward_h.SetTxPower(CalculateTxPower(CalculateDistance(mac_libra_h.GetTxPower(),
+//							mac_libra_h.GetRxPower()))); // Send direct reward message considering the distance
+
+					reward_h.SetTxPower(CalculateTxPower(CalculateDistance(mac_libra_h.GetSrcAddr()))); // Send direct reward message considering the distance
+					// Add some "guard distance", just to mitigate the initial error in distance calculation from Tx/Rx
+					reward_h.SetNextHopDistance(CalculateDistance(mac_libra_h.GetSrcAddr()) + m_dist_error);
+
+					// Set reward value
+					reward = CalculateReward(mac_libra_h.GetOptimalDistance(), mac_libra_h.GetDirectDistance(), m_distances.find(mach.GetDA())->second);
+//					std::cout << "DIRECT DISTANCE: " << mac_libra_h.GetDirectDistance() << "\n";
+					// Since the node is the destination itself, the residual distance is zero
+//					std::cout << "RESIDUAL DISTANCE: " << 0 << "\n";
+
+					reward_h.SetReward(reward);
+
+					reward_msg->AddHeader(reward_h);
+					reward_msg->AddHeader(mach);
+					reward_msg->AddHeader(ash);
+
+				}
+				else
+				{
+					// Otherwise, insert the reward and forward the packet further
+					// Generate reward from the given optimal metric and delta-distance to destination
+					// I.e. how much the total distance has been reduced comparing to the optimal one
+					reward = CalculateReward(mac_libra_h.GetOptimalDistance(), mac_libra_h.GetDirectDistance(), m_distances.find(mach.GetDA())->second);
+
+					// std::cout << "DIRECT DISTANCE: " << mac_libra_h.GetDirectDistance() << "\n";
+					// std::cout << "RESIDUAL DISTANCE: " << m_distances.find(mach.GetDA())->second << "\n";
+
+					// Increment hop count, set reward for the sender node
+					mac_libra_h.IncrementHopCount();
+					mac_libra_h.SetReward(reward);
+
+					// Set aqua-sim-header parameters for correct handling on Phy layer
+					// ash.SetTxTime(GetTxTime(pkt));
+					ash.SetTxTime(Phy()->CalcTxTime(ash.GetSize()));
+					ash.SetErrorFlag(false);
+					ash.SetDirection(AquaSimHeader::DOWN);
+
+					pkt->AddHeader(mac_libra_h);
+					pkt->AddHeader(mach);
+					pkt->AddHeader(ash);
+					// Increment hop_count, set reward
+					ForwardPacket(pkt, mac_libra_h.GetSrcAddr());
+				}
+				return true;
+			}
+
+			// Update the weight value by the reward, if the sender_addr is for this node
+			if (sender_addr == AquaSimAddress::ConvertFrom(m_device->GetAddress()))
+			{
+				// Check the reward
+				// If the reward = 0, then the packet contains no rewards, i.e. the packet has come from the initial source node
+				// In that case, do not update the forwarding table with reward
+				double reward = mac_libra_h.GetReward();
+				if (reward != 0)
+				{
+					// Update forwarding table
+					UpdateWeight(mach.GetSA(), mach.GetDA(), mac_libra_h.GetSrcAddr(), reward);
+				}
+
+			}
+
+			return true;
+		}
+
+		// Direct reward
+		if (mac_libra_h.GetPType() == 7) // 7 - DIRECT REWARD
+		{
+			// If this reward for this node, update weight
+			// Otherwise, discard
+			if (mac_libra_h.GetDstAddr() == AquaSimAddress::ConvertFrom(m_device->GetAddress()))
+			{
+				UpdateWeight(mach.GetSA(), mach.GetDA(), mac_libra_h.GetSrcAddr(), mac_libra_h.GetReward());
+			}
+			return true;
+		}
+
+		else
+		{
+//			std::cout << "Unknown packet type is received: " << mac_libra_h.GetPType() << "\n";
+		}
+
+//	printf("underwaterAquaSimLibraMac: this is neither broadcast nor my packet, just drop it\n");
+	//pkt=0;
+	return false;
+}
+
+
+void
+AquaSimMacLibra::DropPacket(Ptr<Packet> pkt)
+{
+  //this is not necessary... only kept for current legacy issues
+  pkt=0;
+  return;
+}
+
+
+/*
+this program is used to handle the transmitted packet,
+it should be virtual function, different class may have
+different versions.
+*/
+bool
+AquaSimMacLibra::TxProcess(Ptr<Packet> pkt)
+{
+	NS_LOG_FUNCTION(this << pkt);
+
+	// Calculate initial distances
+	if (!m_distances_initialized)
+	{
+		InitializeDistances();
+		m_distances_initialized = true;
+	}
+
+	AquaSimHeader ash;
+	MacHeader mach;
+	MacLibraHeader mac_libra_h;
+
+	pkt->RemoveHeader(ash);
+
+	AquaSimAddress dst_addr = ash.GetDAddr();
+
+	// Populate the list of neighbors within max tx range
+	if (m_inrange_addresses.empty() && m_isInRange)
+	{
+		DiscoverInRangeNodes();
+	}
+
+	// Drop packet if node has no neighbors
+	if (!m_isInRange)
+	{
+		// std::cout << "THE NODE HAS NO NEIGHBORS!!! DROPPING PACKET!!!\n";
+		return false;
+	}
+
+	// Check if the destination is within maximum transmission range or not
+	// If the destination is outside the maximum transmission range, then randomly select any other destination, which is within it
+	if (!IsWithinMaximumRange(dst_addr))
+	{
+		uint32_t address_index = m_rand->GetInteger(0, m_inrange_addresses.size() - 1);
+		// std::cout << "SELECTED ADDRESS INDEX: " << address_index << "\n";
+		// std::cout << "SELECTING THE OTHER DST: " << m_inrange_addresses.at(address_index) << "\n";
+		dst_addr = m_inrange_addresses.at(address_index);
+	}
+
+
+	// mach.SetDA(ash.GetDAddr());
+	ash.SetDAddr(dst_addr);
+	mach.SetDA(dst_addr);
+	mach.SetSA(AquaSimAddress::ConvertFrom(m_device->GetAddress()));
+
+	ash.SetSize(ash.GetSize());
+
+	// ash.SetTxTime(GetTxTime(pkt));
+	ash.SetTxTime(Phy()->CalcTxTime(ash.GetSize()));
+
+	// Set initial reward and hop_count values
+	mac_libra_h.SetHopCount(1);
+	mac_libra_h.SetReward(0);
+	// Set packet type (DATA type), ID
+	mac_libra_h.SetPType(0);
+	mac_libra_h.SetId(m_header_id);
+	m_header_id++;
+
+	pkt->AddHeader(mac_libra_h);
+	pkt->AddHeader(mach);
+	pkt->AddHeader(ash);
+
+	ForwardPacket(pkt->Copy(), AquaSimAddress::ConvertFrom(m_device->GetAddress()));
+
+  return true;  //may be bug due to Sleep/default cases
+}
+
+bool
+AquaSimMacLibra::SendDownFrame (Ptr<Packet> pkt)
+{
+	NS_LOG_FUNCTION(this << pkt);
+	AquaSimHeader ash;
+	MacHeader mach;
+	MacLibraHeader mac_libra_h;
+
+	pkt->RemoveHeader(ash);
+	pkt->RemoveHeader(mach);
+	pkt->RemoveHeader(mac_libra_h);
+
+	// Set mac type to mac header
+	mach.SetDemuxPType(MacHeader::UWPTYPE_MAC_LIBRA);
+
+	ash.SetTimeStamp(Simulator::Now());
+	ash.SetDirection(AquaSimHeader::DOWN);
+	pkt->AddHeader(mac_libra_h);
+	pkt->AddHeader(mach);
+	pkt->AddHeader(ash);
+
+  // Check net_device status
+  // If it is IDLE, send packet down to PHY immediately
+  // otherwise, do random backoff again
+  if (m_device->GetTransmissionStatus() == TransStatus::NIDLE)
+  {
+    // Call parent method to send packet down to PHY
+    SendDown(pkt->Copy());
+    // Go to next packet in queue
+    SendPacket();
+	// Simulator::Schedule(Seconds(GetBackoff()), &AquaSimMacLibra::SendPacket, this);
+  }
+  else
+  {
+	//   std::cout << Simulator::Now().GetSeconds() << "\n";
+    // Do another backoff
+    Simulator::Schedule(Seconds(GetBackoff()), &AquaSimMacLibra::SendDownFrame, this, pkt->Copy());
+  }
+  return true;
+}
+
+// Return a random number in-between given range
+double AquaSimMacLibra::GetBackoff()
+{
+//   return m_rand->GetValue(0.1, 1.0);
+  return m_rand->GetValue(1.0, 5.0);
+}
+
+// Try to send packet to PHY layer, after backoff
+void AquaSimMacLibra::SendPacket()
+{
+	NS_LOG_FUNCTION(this);
+
+  // If queue is empty -> nothing to send -> return
+  if (m_send_buffer.size() == 0)
+  {
+    return;
+  }
+
+  // Get packet from queue
+  Ptr<Packet> pkt = m_send_buffer.front();
+  m_send_buffer.pop();
+
+  SendDownFrame(pkt->Copy());
+}
+
+// Forward packet / frame coming from the application or the network (DATA type)
+bool
+AquaSimMacLibra::ForwardPacket(Ptr<Packet> p, AquaSimAddress sender_addr)
+{
+	AquaSimHeader ash;
+	MacHeader mach;
+	MacLibraHeader mac_libra_h;
+
+	p->RemoveHeader(ash);
+	p->RemoveHeader(mach);
+	p->RemoveHeader(mac_libra_h);
+
+	// Store destination address as integer
+	AquaSimAddress dst_addr = mach.GetDA();
+
+	// Reset the direction if the packet is forwarded by intermediate node
+	ash.SetDirection(AquaSimHeader::DOWN);
+
+	// If it is a source of initial packet, set the optimal_distance and max_hops_number values
+	if (mach.GetSA() == AquaSimAddress::ConvertFrom(m_device->GetAddress()))
+	{
+		// Set the direct distance from this node to the destination
+		mac_libra_h.SetDirectDistance(m_distances.find(dst_addr)->second);
+		int max_hops_number = CalculateHopCount(mac_libra_h.GetDirectDistance(), m_packet_size, m_max_tx_power);
+		uint32_t optimal_distance = mac_libra_h.GetDirectDistance() / (max_hops_number + 1);
+
+//		std::cout << "MAX HOPS NUMBER: " << max_hops_number << "\n";
+//		std::cout << "OPTIMAL DISTANCE: " << optimal_distance << "\n";
+
+		mac_libra_h.SetOptimalDistance(optimal_distance);
+		mac_libra_h.SetMaxHopsNumber(max_hops_number);
+	}
+
+	// Update the forwarding table according to the known distances
+	std::map<AquaSimAddress, AquaSimAddress> src_dst_map;
+	src_dst_map.insert(std::make_pair(mach.GetSA(), dst_addr));
+
+	if (m_forwarding_table.count(src_dst_map) == 0)
+	{
+		// Create new entry with initial weight
+		std::map<AquaSimAddress, double> m; // {next_hop : weight}
+
+		// For each possible destination / distance - calculate the initial weight based on the optimal distance metric
+//			std::cout << "DISTANCES SIZE: " << m_distances.size() << "\n";
+		for (auto const& x : m_distances)
+		{
+			// Calculate initial weight (reward)
+			m.insert(std::make_pair(x.first, CalculateReward(mac_libra_h.GetOptimalDistance(), x.second, 0)));
+//				std::cout << "Creating new table entry with REWARD: " << reward / 2 << "\n";
+			NS_LOG_DEBUG("Creating new table entry with WEIGHT: " << CalculateReward(mac_libra_h.GetOptimalDistance(), x.second, 0));
+		}
+
+		m_forwarding_table.insert(std::make_pair(src_dst_map, m));
+//			std::cout << "TABLE SIZE: " << m_forwarding_table.size() << "\n";
+	}
+
+	// Select next_hop neighbor and send down the packet
+	// If the hop_count exceeds the threshold, then send the packet directly to the destination
+	AquaSimAddress next_hop_addr;
+	if (mac_libra_h.GetHopCount() > mac_libra_h.GetMaxHopsNumber())
+	{
+//			std::cout << "HOP COUNT EXCEEDED THRESHOLD. Sending to DST.\n";
+		next_hop_addr = dst_addr;
+	}
+	else
+	{
+		next_hop_addr = SelectNextHop(mach.GetSA(), dst_addr);
+	}
+
+	// Set next hop parameters - update src/dst fields
+	mac_libra_h.SetSrcAddr(AquaSimAddress::ConvertFrom(m_device->GetAddress()));
+//		std::cout << "Next hop addr: " << next_hop_addr << "\n";
+	mac_libra_h.SetDstAddr(next_hop_addr);
+
+	// Set the direct distance from this node to the destination
+	mac_libra_h.SetDirectDistance(m_distances.find(dst_addr)->second);
+//		std::cout << "DIRECT DISTANCE FROM LIST: " << m_distances.find(dst_addr)->second << "\n";
+
+	// Set sender address for the reward
+	mac_libra_h.SetSenderAddr(sender_addr);
+
+	// Set tx time and size
+	// ash.SetSize(mac_libra_h.GetSerializedSize() + mach.GetSerializedSize() + p->GetSize());
+	ash.SetSize(p->GetSize());
+	// DO NOT CONSIDER HEADER OVERHEAD IN THE TESTS
+	ash.SetTxTime(Phy()->CalcTxTime(p->GetSize()));
+
+	ash.SetErrorFlag(false);
+	ash.SetDirection(AquaSimHeader::DOWN);
+
+	// Set tx power for the given packet. The tx_power must be enough to reach the initial sender node.
+	// Insert the next_hop distance to each sent packet
+	if (AquaSimAddress::ConvertFrom(m_device->GetAddress()) == sender_addr)
+	{
+		// Set tx_power sufficient to reach the destination
+		mac_libra_h.SetTxPower(CalculateTxPower(m_distances.find(next_hop_addr)->second));
+		// Add some "guard distance", just to mitigate the initial error in distance calculation from Tx/Rx
+		mac_libra_h.SetNextHopDistance(m_distances.find(next_hop_addr)->second + m_dist_error);
+	}
+	else
+	{
+		// Else, consider the tx_power to reach the sender node as well
+		if ((m_distances.find(next_hop_addr)->second) <= (m_distances.find(sender_addr)->second))
+		{
+			// Set tx_power to reach the sender
+			mac_libra_h.SetTxPower(CalculateTxPower(m_distances.find(sender_addr)->second));
+			// Add some "guard distance", just to mitigate the initial error in distance calculation from Tx/Rx
+			mac_libra_h.SetNextHopDistance(m_distances.find(sender_addr)->second + m_dist_error);
+		}
+		else
+		{
+			// Set tx_power sufficient to reach the destination
+			mac_libra_h.SetTxPower(CalculateTxPower(m_distances.find(next_hop_addr)->second));
+			// Add some "guard distance", just to mitigate the initial error in distance calculation from Tx/Rx
+			mac_libra_h.SetNextHopDistance(m_distances.find(next_hop_addr)->second + m_dist_error);
+		}
+	}
+
+	p->AddHeader(mac_libra_h);
+	p->AddHeader(mach);
+	p->AddHeader(ash);
+
+	// Send Frame
+	// std::cout << ash.GetTxTime() << "\n";
+
+	// Start sending, if queue is empty
+	if (m_send_buffer.size() == 0)
+	{
+		// Push packet to MAC send queue
+		m_send_buffer.push(p->Copy());
+		SendPacket();
+	}
+	else
+	{
+		m_send_buffer.push(p->Copy());
+	}
+
+	return true;
+}
+
+// Select next hop based on softmax selection
+AquaSimAddress
+AquaSimMacLibra::SelectNextHop(AquaSimAddress src_addr, AquaSimAddress dst_addr)
+{
+	// Forwarding table has the following format: {dst_adddr: {next_hop1 : w1, ... next_hopN : wN}}
+	// For the given dst_addr, select a next_hop_addr with max weight (greedy method for now)
+	double max_value = 0;
+	AquaSimAddress next_hop_addr = 0;
+
+	std::map<AquaSimAddress, AquaSimAddress> src_dst_map;
+	src_dst_map.insert(std::make_pair(src_addr, dst_addr));
+
+	// Store the next-hop address and the corresponding selection probability, based on current weights
+	std::vector<AquaSimAddress> next_hop_addresses;
+	std::vector<double> selection_probabilities;
+	
+	// Calculate selection probabilities
+	// Find weight sum
+	double weight_sum = 0;
+	for (auto const& x : m_forwarding_table.find(src_dst_map)->second)
+	{
+		weight_sum += exp(x.second);
+	}
+
+	// Store selection probabilities
+	// int i = 0;
+	for (auto const& x : m_forwarding_table.find(src_dst_map)->second)
+	{
+		selection_probabilities.push_back(exp(x.second) / weight_sum);
+		next_hop_addresses.push_back(x.first);
+		// std::cout << "Next hop: " << x.first << "\n";
+		// std::cout << "Selection probability: " << selection_probabilities.at(i) << "\n";
+		// i++;
+	}
+
+    // Select next-hop neighbor based on the softmax probabilities
+	uint32_t next_hop_index;
+	double point = m_rand->GetValue();
+    double cur_cutoff = 0;
+
+    for (uint32_t i=0; i<selection_probabilities.size(); i++) {
+		// std::cout << "cur_cutoff: " << cur_cutoff << "\n";
+		// std::cout << "selection prob: " << selection_probabilities[i] << "\n";
+		// std::cout << "point: " << point << "\n";
+        cur_cutoff += selection_probabilities[i];
+        if (point < cur_cutoff)
+		{
+			next_hop_index = i;
+			break;
+		}
+      next_hop_index = selection_probabilities.size()-1;
+    }
+    
+	next_hop_addr = next_hop_addresses[next_hop_index];
+
+// 	// Old greedy method:
+// 	// Iterate through the weights to find the max value
+// 	for (auto const& x : m_forwarding_table.find(src_dst_map)->second)
+// 	{
+// 		if (max_value <= x.second)
+// 		{
+// 			max_value = x.second;
+// 			next_hop_addr = x.first;
+// 		}
+// //		std::cout << x.first << " " << x.second << "\n";
+// 	}
+
+//	std::cout << "MAX VALUE: " << max_value << "\n";
+	NS_LOG_DEBUG("MAX VALUE: " << max_value);
+
+//	std::cout << "NEXT HOP ADDR: " << next_hop_addr << "\n";
+	NS_LOG_DEBUG("NEXT HOP ADDR: " << next_hop_addr);
+
+	return next_hop_addr;
+}
+
+// Update weight in forwarding table
+bool
+AquaSimMacLibra::UpdateWeight(AquaSimAddress src_addr, AquaSimAddress dst_addr, AquaSimAddress next_hop_addr, double reward)
+{
+//	std::cout << "UPDATED REWARD: " << reward << "\n";
+	NS_LOG_DEBUG("UPDATED REWARD: " << reward);
+
+	std::map<AquaSimAddress, AquaSimAddress> src_dst_map;
+	src_dst_map.insert(std::make_pair(src_addr, dst_addr));
+
+	if (m_forwarding_table.count(src_dst_map) == 0)
+	{
+		// Create new entry with initial weight according to given reward
+		std::map<AquaSimAddress, double> m; // {next_hop : weight}
+
+		m.insert(std::make_pair(next_hop_addr, reward));
+//		std::cout << "Creating new table entry with REWARD: " << reward << "\n";
+//		NS_LOG_DEBUG("Creating new table entry with REWARD: " << reward / 2);
+
+		m_forwarding_table.insert(std::make_pair(src_dst_map, m));
+	}
+	else
+	{
+		// Check if the next_hop_entry exist, if not - create one and return
+		if (m_forwarding_table.find(src_dst_map)->second.count(next_hop_addr) == 0)
+		{
+			m_forwarding_table.find(src_dst_map)->second.insert(std::make_pair(next_hop_addr, reward));
+			return 0;
+		}
+
+		double current_weight = m_forwarding_table.find(src_dst_map)->second.find(next_hop_addr)->second;
+//		NS_LOG_DEBUG("CURRENT WEIGHT: " << current_weight << " Node Address: " << AquaSimAddress::ConvertFrom(m_device->GetAddress()));
+//		NS_LOG_DEBUG("REWARD: " << reward);
+//		NS_LOG_DEBUG("TABLE SIZE: " << m_forwarding_table.size());
+
+		// Calculate sample average and update the weight
+		m_forwarding_table.find(src_dst_map)->second.at(next_hop_addr) = (current_weight + reward) / 2;
+	}
+	return 0;
+}
+
+double
+AquaSimMacLibra::CalculateReward(double optimal_distance, double direct_distance, double current_distance)
+{
+	// Calculate weight based on the difference between optimal_distance and D(Tx,Rx)
+//	std::cout << "DISTANCE DIFFERENCE: " << (direct_distance - current_distance) << "\n";
+	if ((direct_distance - current_distance) <= 0)
+	{
+		// Return minimum possible reward
+		return m_min_reward;
+	}
+
+	// TODO: Think out how to give more weight to a closer node, then to a more distant one.
+	if (optimal_distance <= (direct_distance - current_distance))
+	{
+		return 100 * (optimal_distance / (direct_distance - current_distance));
+	}
+	else
+	{
+		return 100 * ((direct_distance - current_distance) / optimal_distance);
+	}
+}
+
+double
+AquaSimMacLibra::CalculateDistance(double tx_power, double rx_power)
+{
+	// A very rough approximation of rayleigh model, used in the propagation module:
+	// rx_power = tx_power / d^k * alpha^(d/1000), k = 2
+	// This approximation works if freq=25kHz, i.e. alpha ~ 4
+	NS_LOG_DEBUG("TX_POWER_CALC_DISTANCE: " << tx_power);
+	NS_LOG_DEBUG("RX_POWER_CALC_DISTANCE: " << rx_power);
+	return sqrt(tx_power / rx_power);
+}
+
+void
+AquaSimMacLibra::InitializeDistances()
+{
+	for (uint32_t i=1; i <= m_device->GetChannel()->GetNDevices(); i++)
+	{
+		if (i != (m_device->GetNode()->GetId() + 1))
+		{
+//	    		std::cout << "ADDR: " << AquaSimAddress::ConvertFrom(m_device->GetChannel()->GetDevice(i-1)->GetAddress()) << " " << m_device->GetChannel()->GetDevice(i-1)->GetAddress() << "\n";
+			m_distances.insert(std::make_pair(AquaSimAddress::ConvertFrom(m_device->GetChannel()->GetDevice(i-1)->GetAddress()),
+					CalculateDistance(AquaSimAddress::ConvertFrom(m_device->GetChannel()->GetDevice(i-1)->GetAddress()))));
+		}
+	}
+}
+
+double
+AquaSimMacLibra::CalculateDistance(AquaSimAddress dst_addr)
+{
+	double dist = 0;
+
+	// Get the distance from the mobility model
+    Ptr<Object> sObject = m_device->GetNode();
+    Ptr<MobilityModel> senderModel = sObject->GetObject<MobilityModel> ();
+
+    Ptr<Object> rObject = m_device->GetChannel()->GetDevice(dst_addr.GetAsInt() - 1)->GetNode();
+    Ptr<MobilityModel> recvModel = rObject->GetObject<MobilityModel> ();
+
+    dist = senderModel->GetDistanceFrom(recvModel);
+
+    // std::cout << "MOBILITY DISTANCE: " << dist << "\n";
+
+    return dist;
+}
+
+double
+AquaSimMacLibra::CalculateTxPower(double d)
+{
+	  // Calculate Tx power given the distance and expected Rx_threshold
+	  // The calculation is based on Rayleight model, used in the aqua-sim-propagation module:
+	  // Rx = Tx / (d^k * alpha^(d/1000)), k = 2, alpha = 4.07831, (f = 25kHz)
+	// double tx_power = pow(d, 2) * pow(4.07831, (d / 1000)) * (m_rx_threshold + 0.0003); // 0.0003 to adjust the model
+	double tx_power = pow(d, 2) * pow(4.07831, (d / 1000)) * m_rx_threshold;
+	NS_LOG_DEBUG("GIVEN DISTANCE: " << d);
+	NS_LOG_DEBUG("CALCULATED TX POWER: " << tx_power);
+
+	if (tx_power > m_max_tx_power)
+	{
+		return m_max_tx_power;
+	}
+	else
+	{
+		return tx_power;
+	}
+}
+
+bool
+AquaSimMacLibra::IsWithinMaximumRange(AquaSimAddress dst_addr)
+{
+	if (dst_addr == AquaSimAddress::ConvertFrom(m_device->GetAddress()))
+	{
+		return false;
+	}
+	if (CalculateDistance(dst_addr) > m_max_range)
+	{
+		// std::cout << "THE DST IS OUTSIDE TX RANGE: " << CalculateDistance(dst_addr) << "\n";
+		return false;
+	}
+	else
+	{
+		return true;
+	}	
+}
+
+void
+AquaSimMacLibra::DiscoverInRangeNodes()
+{
+	m_isInRange = false;
+	for (uint32_t i=1; i <= m_device->GetChannel()->GetNDevices(); i++)
+	{
+		if (i != (m_device->GetNode()->GetId() + 1))
+		{
+			AquaSimAddress address = AquaSimAddress::ConvertFrom(m_device->GetChannel()->GetDevice(i-1)->GetAddress());
+			if (IsWithinMaximumRange(address))
+			{
+				// std::cout << "ADDRESS in RANGE: " << address << "\n";
+				m_inrange_addresses.push_back(address);
+				m_isInRange = true;
+			}
+		}
+	}
+}
+
+void AquaSimMacLibra::DoDispose()
+{
+  NS_LOG_FUNCTION(this);
+  AquaSimMac::DoDispose();
+}

--- a/model/aqua-sim-mac-libra.h
+++ b/model/aqua-sim-mac-libra.h
@@ -1,0 +1,216 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Author: Dmitrii Dugaev <ddugaev@gradcenter.cuny.edu>
+ * based on aqua-sim-mac-aloha model with no ACKs and backoffs
+ */
+
+#ifndef AQUA_SIM_MAC_LIBRA_H
+#define AQUA_SIM_MAC_LIBRA_H
+
+#include "aqua-sim-mac.h"
+#include <math.h>
+
+
+namespace ns3 {
+
+/**
+ * \ingroup aqua-sim-ng
+ *
+ * \brief Routing MAC, based on aloha-mac with no ACKs and backoffs
+ */
+class AquaSimMacLibra : public AquaSimMac
+{
+public:
+  AquaSimMacLibra();
+  int64_t AssignStreams (int64_t stream);
+
+  static TypeId GetTypeId(void);
+
+  // to process the incoming packet
+  virtual bool RecvProcess (Ptr<Packet>);
+  void CallbackProcess ();
+  void DropPacket (Ptr<Packet>);
+
+  // Forward packet / frame from upper layers / network, keep track of the sender node
+//  bool ForwardPacket (Ptr<Packet>, AquaSimAddress sender_addr, int hop_count, double reward);
+  bool ForwardPacket (Ptr<Packet>, AquaSimAddress sender_addr);
+
+  // Send down frame using broadcast-mac backoff logic
+  bool SendDownFrame (Ptr<Packet>);
+
+  void SendPacket();
+  double GetBackoff();
+
+  // Send down frame TODO: fix the order of send downs
+  bool Send(Ptr<Packet>);
+
+  // Resend frame from the send_buffer
+  void ResendFrame();
+
+  // Select next_hop_node for given destination, return its address
+//  AquaSimAddress SelectNextHop (AquaSimAddress dst_addr);
+  AquaSimAddress SelectNextHop (AquaSimAddress src_addr, AquaSimAddress dst_addr);
+
+  // Filter duplicate broadcast service messages
+  bool FilterDuplicateInit (AquaSimAddress src_addr);
+
+  // Generate reward packet
+  double GenerateReward (AquaSimAddress dst_addr);
+
+  // Update path weight in forwarding table by corresponding reward value
+//  bool UpdateWeight(AquaSimAddress address, AquaSimAddress next_hop_addr, double reward);
+  bool UpdateWeight(AquaSimAddress src_addr, AquaSimAddress dst_addr, AquaSimAddress next_hop_addr, double reward);
+
+  // Calculate rewards based on given distances
+//  double CalculateWeight (double distance);
+  double CalculateReward (double optimal_metric, double direct_distance, double current_distance);
+
+  // Calculate and update distance list
+  void UpdateDistance (double tx_power, double rx, AquaSimAddress dst_addr);
+
+  // Calculate the distance between the src and dst nodes, based on Tx and Rx powers
+  // For that, a very rough approximation model of Rayleigh is used, if frequency = 25 kHz!
+  double CalculateDistance (double tx_power, double rx_power);
+  // Get more precise distance from mobility model (while more accurate TX/RX formula hasn't been figured out)
+  double CalculateDistance (AquaSimAddress dst_addr);
+
+  // Calculate Tx power given the distance and expected Rx_threshold
+  // The calculation is based on Rayleight model, used in the aqua-sim-propagation module:
+  // Rx = Tx / (d^k * alpha^(d/1000)), k = 2, alpha = 4, (f = 25kHz)
+  double CalculateTxPower (double distance);
+
+  // Calculate the number of relays that can minimize the energy consumption
+  // The return value is the ideal number of relays
+//  int CalculateHopCount(double distance, int packet_size, int link_speed, double p_rx, double p_tx_max);
+  uint8_t CalculateHopCount(double distance, int packet_size, double p_tx_max);
+
+  // Check if the destination node is within the maximum transmission range of the source node or not
+  bool IsWithinMaximumRange (AquaSimAddress dst_addr);
+
+  // Popolate the in_range node list
+  void DiscoverInRangeNodes ();
+
+  // Initialized the distances between this node and all the other nodes
+  void InitializeDistances();
+
+  // to process the outgoing packet
+  virtual bool TxProcess (Ptr<Packet>);
+
+  // MAC states
+  enum MacRoutingStatus {
+	  DATA_TX,
+	  DATA_RX,
+	  IDLE
+    };
+
+protected:
+  virtual void DoDispose();
+  // Expiration handlers. Not used for now.
+  void RewardExpirationHandler(std::map<AquaSimAddress, AquaSimAddress> dst_to_next_hop_map);
+
+
+private:
+  Ptr<UniformRandomVariable> m_rand;
+
+  // Forwarding table to select next-hop nodes, in a format: {dst_addr : [next_hop_addr: weight]}
+//  std::map<AquaSimAddress, std::map<AquaSimAddress, double>> m_forwarding_table;
+  // Map of (src, dst) pair and the corresponding weight
+  std::map<std::map<AquaSimAddress, AquaSimAddress>, std::map<AquaSimAddress, double>> m_forwarding_table;
+
+  // Store the packets in send_queue until path discovery procedure is successful or failed, in a format:
+  // {dst_addr: packet_queue}
+  std::map<AquaSimAddress, std::queue<Ptr<Packet>>> m_send_queue;
+
+  // Store the packets which have been already triggered to be sent, but failed due to device not idle status
+  std::queue<Ptr<Packet>> m_send_buffer;
+
+  // Store reward expiration timestamps, needed when the expire event is triggered by the scheduler,
+  // or when the reward message is received,
+  // in a format: {{dst_addr : next_hop_addr} : last_recevied_reward_timestamp}
+  std::map<std::map<AquaSimAddress, AquaSimAddress>, Time> m_reward_expirations;
+
+  // Store INIT expiration timestamps, needed when the expire event is triggered by the scheduler,
+  // or when the INIT message is received,
+  // in a format: {dst_addr: last_recevied_init_timestamp}
+  std::map<AquaSimAddress, Time> m_init_expirations;
+
+  // Store list of already received INITs, with the last received timestamp to handle duplicate frames
+  std::map<AquaSimAddress, Time> m_init_list;
+
+  // Store list of {dst_addr, sender_addr} pairs to periodically generate the reward packets back to sender
+  std::map<std::map<AquaSimAddress, AquaSimAddress>, Time> m_reward_delays;
+
+  // ACK / Reward delay on receiver side
+  Time m_reward_delay = Seconds(1);
+  // Reward wait timeout, in seconds
+  Time m_reward_timeout = Seconds(30) + m_reward_delay;
+
+  // INIT wait timeout, in seconds
+  Time m_init_timeout = Seconds(10);
+
+  // Store the distances to each destination
+  std::map<AquaSimAddress, double> m_distances;
+
+  // Default negative reward value
+  double m_negative_reward = -1;
+
+  // Maximum hop-count for packets (to avoid loops)
+  int m_max_hop_count = 10;
+
+  // Max transmission range
+  double m_max_range = 1500; // meters
+
+  // Expected Rx_threshold, in Watts
+  // double m_rx_threshold = 3.27 * pow(10, -8);
+  // RX_threshold calculated for TX power = 60 Watts at distance of 1250 meters
+  // double m_rx_threshold = 6.62568 * pow(10, -6);
+  double m_rx_threshold = 5.4764*pow(10,(-8.0));
+  // RX_threshold calculated for TX power = 60 Watts at distance of 1500 meters
+  // double m_rx_threshold = 3.23778 * pow(10, -6);
+
+  // Max tx_power
+  double m_max_tx_power = 20; // Watts
+
+  // Hop count threshold - send the DATA packet directly to the destination, if the hop count value exceeds the threshold
+  int m_hop_count_threshold = 3;
+
+  // Minimum possible reward
+  double m_min_reward = 0.001;
+
+  // Data transmission time interval
+  // Time duration of the DATA_TX / RX states before transition to IDLE
+  // I.e., how much data should be transmitted within a single RTS/CTS handshake
+  Time m_data_timeout = Seconds(10);
+
+  // Distance calculation error, meters
+  // double m_dist_error = 0.1;
+  double m_dist_error = 0.001;
+
+  // Data packet size from upper layers
+  int m_packet_size = 50;
+
+  // Header id counter
+  uint32_t m_header_id = 0;
+
+  // Store number of nodes in a network
+  uint16_t m_nnodes = 0;
+
+  // Store a list of destination address, which are within maximum transmission range
+  std::vector<AquaSimAddress> m_inrange_addresses;
+
+  // Also, make sure that the given node has at least one neighbor in the maximum transmission range (
+  //  (for the edge-case, when the max tx range is too short)
+  bool m_isInRange = true;
+
+  // Fix the number of intermediate nodes (for currernt experiments!!!)
+  uint32_t m_nintermediate_nodes = 0;
+
+  // Flag to indicate whether the initial distances are initialized
+  bool m_distances_initialized = false;
+
+
+};  // class AquaSimMacLibra
+
+} // namespace ns3
+
+#endif /* AQUA_SIM_MAC_LIBRA_H */

--- a/model/aqua-sim-mac-sfama.h
+++ b/model/aqua-sim-mac-sfama.h
@@ -194,8 +194,9 @@ private:
 	//index_ is the mac address of this node
 	double m_guardTime;  //need to be binded
 	double m_slotLen;
-    double m_rtsCtsAckNumSlotWait;
-    double m_maxPrTimeSec;
+
+	// Store data packet size value from the app
+	double m_packet_size = 50;
 
 	bool m_isInRound;
 	bool m_isInBackoff;
@@ -204,7 +205,6 @@ private:
 
 	int m_maxBurst; /*maximum number of packets in the train*/
 	double m_dataSendingInterval;
-    double m_lastRxDataSlotsNum;
 
 	//wait to send pkt at the beginning of next slot
 	AquaSimSFama_Wait_Send_Timer m_waitSendTimer;

--- a/model/aqua-sim-phy-cmn.h
+++ b/model/aqua-sim-phy-cmn.h
@@ -118,6 +118,9 @@ public:
   virtual void SetTransRange(double range);
   virtual double GetTransRange();
 
+  // Check collision status of the first received packet when net_device was in IDLE state
+  virtual void CollisionCheck(Ptr<Packet> packet);
+
 protected:
   virtual Ptr<Packet> PrevalidateIncomingPkt(Ptr<Packet> p);
   virtual void UpdateTxEnergy(Time txTime);
@@ -190,6 +193,10 @@ private:
 
   ns3::TracedCallback<Ptr<Packet>, double > m_rxLogger;
   ns3::TracedCallback<Ptr<Packet>, double > m_txLogger;
+
+  // Collision flag in order to monitor whether there have been incoming packets wihtin the TxTime delay of the original packet.
+  // If yes, then mark the original packet as collided as well.
+  bool m_collision_flag = false;
 
 }; //AquaSimPhyCmn
 

--- a/scripts/print_results_aloha.py
+++ b/scripts/print_results_aloha.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+"""
+Print the results obtained from the trace files.
+"""
+
+
+import trace_parser_aloha
+import numpy
+
+import os.path
+
+
+PACKET_SIZE = 800
+# N_HOPS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25]
+# N_HOPS = [6, 7, 8, 9, 10]
+# N_HOPS = [0, 1]
+# N_HOPS = [0, 3, 5, 7, 10]
+# NODES = [50, 100, 150, 200, 250]
+# NODES = [25, 50, 75, 100, 125]
+# NODES = [64, 80, 96, 112, 128]
+NODES = [128]
+
+# LAMBDAS = ['0.01', '0.02', '0.03', '0.04', '0.05', '0.06', '0.07', '0.08', '0.09', '0.10']
+# LAMBDAS = ['0.20', '0.30', '0.40', '0.50', '0.60', '0.70', '0.80', '0.90', '1.00']
+# LAMBDAS = ['0.01', '0.05', '0.10', '0.15', '0.20', '0.25', '0.30', '0.35', '0.40', '0.45', '0.50', '0.55', '0.60']
+LAMBDAS = ['0.01']
+# LAMBDAS = ['0.20', '0.40', '0.60', '0.80']
+METRICS = ["collisions", "energy", "energy_per_bit", "throughput", "pdr", "hop_count"]
+# METRICS = ["hop_count"]
+METRICS_NAMES = {"collisions": "Total number of collisions", "energy": "Total energy consumption, Joules", "energy_per_bit": "Energy per Bit, Joules", "throughput": "Total network throughput, bps", 
+                "pdr": "Packet Delivery Ratio (PDR)", "hop_count": "Average Hop Count"}
+VALUES = {"collisions": [], "energy": [], "energy_per_bit": [], "throughput": [], "pdr": [], "hop_count": []}
+
+
+TRACE_PATH = "../../../"
+TRACE_NAME = "aloha-density-trace-%s-%s-0.asc"
+PRINT_FILENAME = "aloha-density-%s.txt" # insert number of nodes
+
+
+def get_converged_stats(trace, l, n_nodes):
+    TX_TIME = 800 * 8 / 10000.0    # packet_size * 8 / channel_bps
+    RX_POWER = 0.82     # Watts
+    
+    packet_paths = {}
+    attempt_number = 1
+    for i in xrange(len(trace["TS"])):
+        if trace["RX/TX-MODE"][i] == "TX" and trace["PTYPE"][i] == "DATA":
+            unique_id = trace["UNIQUE_ID"][i]
+            hop = (int(trace["MAC_SRC_ADDR"][i]), int(trace["MAC_DST_ADDR"][i]))
+            dst_node = int(trace["MAC_DST_ADDR"][i])
+            tx_energy = float(trace["TX_POWER"][i]) * TX_TIME
+            rx_energy = RX_POWER * TX_TIME
+            ts = round(float(trace["TS"][i]) / 1000000000.0, 2)   # turn to seconds
+
+            if unique_id not in packet_paths:
+                packet_paths[unique_id] = [[hop], dst_node, (tx_energy + rx_energy), ts, attempt_number]
+                attempt_number += 1
+            else:
+                packet_paths[unique_id][0].append(hop)
+                packet_paths[unique_id][2] += (tx_energy + rx_energy)
+
+    # Filter out the packets which have been lost during the transmission - the ones which didn't reach the destination node
+    packets_to_remove = []
+    for packet in packet_paths:
+        if packet_paths[packet][0][-1][1] != packet_paths[packet][1]:
+            packets_to_remove.append(packet)
+
+    for packet in packets_to_remove:
+        del packet_paths[packet]
+
+    # print packet_paths
+
+    # Store the information how many times a path has been chosen, and its energy consumption
+    path_stats = {} # format: {path: [times_used, energy, attempt_number]}
+    for packet in packet_paths:
+        path = tuple(packet_paths[packet][0])
+
+        if path not in path_stats:
+            path_stats[path] = [1, packet_paths[packet][2], packet_paths[packet][3], packet_paths[packet][4]]
+        else:
+            path_stats[path][0] += 1
+
+    # calculate percentage of the path usage
+    total_paths_number = 0
+    for path in path_stats:
+        total_paths_number += path_stats[path][0]
+
+    for path in path_stats:
+        path_stats[path][0] = round(100.0 * path_stats[path][0] / float(total_paths_number), 2)
+
+    # print path_stats
+    # Find converged path
+    max_usage_percentage = 0
+    converged_path = None
+    converged_attempts = 0
+    converge_time = 0
+    converged_path_energy = 0 
+    for path in path_stats:
+        if path_stats[path][0] > max_usage_percentage:
+            max_usage_percentage = path_stats[path][0]
+            converged_path = path
+            converged_attempts = path_stats[path][3]
+            converge_time = path_stats[path][2]
+            converged_path_energy = path_stats[path][1]
+
+    # print converged_path
+    # print converged_attempts
+    # print converge_time
+    # print converged_path_energy
+
+    # Check if the converged path is optimal or not
+    # Get optimal path from the text file
+    optimal_path_filename = "optimal_path-%s-%s" % (l, n_nodes)
+    with open(optimal_path_filename, "r") as f:
+        raw = f.readlines()
+
+        path_line = raw[-1].split("\t")[-1].split(" ")[:-1]
+
+        optimal_path = []
+        for node in path_line:
+            optimal_path.append(int(node) + 1)
+        
+        # print "energy:", raw[-1].split("\t")[-3]
+        optimal_path_energy = float(raw[-1].split("\t")[-3])
+
+    converged_path_formatted = []
+    for hop in converged_path:
+        converged_path_formatted.append(hop[0])
+    converged_path_formatted.append(hop[1])
+
+    # print optimal_path
+    # print converged_path_formatted
+    # print converged_path
+
+    if (optimal_path == converged_path_formatted):
+        isOptimal = 1
+    else:
+        isOptimal = 0
+
+    return converged_attempts, converge_time, isOptimal, converged_path_energy, optimal_path_energy
+
+# Print the results to a file
+def print_results():
+    # for n_nodes in NODES:
+    for l in LAMBDAS:
+
+        file_name = PRINT_FILENAME % l
+        if not os.path.exists(file_name):
+            f =open(file_name, "a")
+            # f.write("Density\tNodesNumber\tLambda\tTxPackets\tRxPackets\tTxCount\tRxCount\tCollisionCount\tTotalEnergyConsumption\tEnergyPerBit\tTotalThroughput\tPDR\tAvgHopCount\tAvgDelay\tConvergedAttempt\tConvergeTime\tIsOptimal?\tEnergyConsumptionConvergedPath\tEnergyConsumptionOptimalPath\tOptimalConvergedRatio\n")
+            f.write("Density\tNodesNumber\tLambda\tTxPackets\tRxPackets\tTxCount\tRxCount\tCollisionCount\tTotalEnergyConsumption\tEnergyPerBit\tTotalThroughput\tPDR\n")
+
+        else:
+            f =open(file_name, "a")
+            
+        # line = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s"
+        line = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s"
+
+        # for l in LAMBDAS:
+        for n_nodes in NODES:
+
+            for metric in METRICS:
+                VALUES[metric] = []
+            x = []
+
+            events = trace_parser_aloha.parse_events((TRACE_PATH + TRACE_NAME) % (l, n_nodes))
+            trace, node_info = trace_parser_aloha.parse_fields(events)
+
+            # converged_attempts, converge_time, is_optimal, converged_path_energy, optimal_path_energy = get_converged_stats(trace, l, n_nodes)
+
+            # # Print results to file
+            # n_recv_packets = trace_parser_aloha.calc_recv_packets(trace)
+            # total_energy = trace_parser_aloha.calc_energy_consumption(node_info)
+            # data = (n_nodes/100., n_nodes, l, trace_parser_aloha.calc_sent_packets(trace), n_recv_packets, 
+            # trace_parser_aloha.calc_tx_calls(trace), trace_parser_aloha.calc_rx_calls(trace), trace_parser_aloha.calc_total_collisions(node_info), 
+            # round(total_energy, 2), round(float(total_energy) / (n_recv_packets * PACKET_SIZE * 8), 4), round(trace_parser_aloha.calc_throughput(trace), 2),
+            # round(trace_parser_aloha.calc_pdr(trace), 2), round(trace_parser_aloha.calc_hop_count(trace), 2), round(trace_parser_aloha.calc_delay(trace), 2), 
+            # converged_attempts, converge_time, is_optimal, round(converged_path_energy, 4), round(optimal_path_energy, 4), 
+            # round(optimal_path_energy/converged_path_energy, 4))
+
+            n_recv_packets = trace_parser_aloha.calc_recv_packets(trace)
+            total_energy = trace_parser_aloha.calc_energy_consumption(node_info)
+            data = (n_nodes/100., n_nodes, l, trace_parser_aloha.calc_sent_packets(trace), n_recv_packets, 
+            trace_parser_aloha.calc_tx_calls(trace), trace_parser_aloha.calc_rx_calls(trace), trace_parser_aloha.calc_total_collisions(node_info), 
+            round(total_energy, 2), round(float(total_energy) / (n_recv_packets * PACKET_SIZE * 8), 4), round(trace_parser_aloha.calc_throughput(trace), 2),
+            round(trace_parser_aloha.calc_pdr(trace), 2))
+
+
+            f.write(line % data)
+            # f.write(str(trace_parser_aloha.calc_hop_count(trace)))
+            f.write("\n")
+            f.flush()
+
+        f.close()
+
+
+def main():
+    print_results()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/print_results_libra.py
+++ b/scripts/print_results_libra.py
@@ -1,0 +1,206 @@
+#!/usr/bin/python
+"""
+Plot the results, obtained from the trace files.
+"""
+
+
+
+import trace_parser_libra
+import numpy
+
+import os.path
+
+
+PACKET_SIZE = 800
+# N_HOPS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25]
+# N_HOPS = [6, 7, 8, 9, 10]
+# N_HOPS = [0, 1]
+# N_HOPS = [0, 3, 5, 7, 10]
+# NODES = [50, 100, 150, 200, 250]
+# NODES = [25, 50, 75, 100, 125]
+# NODES = [64, 80, 96, 112, 128]
+NODES = [128]
+
+# LAMBDAS = ['0.01', '0.02', '0.03', '0.04', '0.05', '0.06', '0.07', '0.08', '0.09', '0.10']
+# LAMBDAS = ['0.01', '0.05', '0.10', '0.15', '0.20', '0.25', '0.30', '0.35', '0.40', '0.45', '0.50', '0.55', '0.60']
+LAMBDAS = ['0.01']
+# LAMBDAS = ['0.01', '0.20', '0.40', '0.60', '0.80', '1.00']
+# LAMBDAS = ['0.20', '0.40', '0.60', '0.80']
+METRICS = ["collisions", "energy", "energy_per_bit", "throughput", "pdr", "hop_count"]
+# METRICS = ["hop_count"]
+METRICS_NAMES = {"collisions": "Total number of collisions", "energy": "Total energy consumption, Joules", "energy_per_bit": "Energy per Bit, Joules", "throughput": "Total network throughput, bps", 
+                "pdr": "Packet Delivery Ratio (PDR)", "hop_count": "Average Hop Count"}
+VALUES = {"collisions": [], "energy": [], "energy_per_bit": [], "throughput": [], "pdr": [], "hop_count": []}
+
+
+TRACE_PATH = "../../../"
+TRACE_NAME = "libra-density-trace-%s-%s-0.asc"
+PRINT_FILENAME = "libra-density-%s.txt" # insert number of nodes
+
+
+def get_converged_stats(trace, l, n_nodes):
+    TX_TIME = 800 * 8 / 10000.0    # packet_size * 8 / channel_bps
+    RX_POWER = 0.82     # Watts
+    
+    packet_paths = {}
+    attempt_number = 1
+    for i in range(len(trace["TS"])):
+        # if trace["RX/TX-MODE"][i] == "TX" and trace["PTYPE"][i] == 0:
+        #     print trace["UNIQUE_ID"][i], trace["SRC_ADDR"][i], trace["DST_ADDR"][i], trace["MAC_SRC_ADDR"][i], trace["MAC_DST_ADDR"][i]
+
+        if trace["RX/TX-MODE"][i] == "TX" and trace["PTYPE"][i] == 0:
+            unique_id = trace["UNIQUE_ID"][i]
+            hop = (int(trace["SRC_ADDR"][i]), int(trace["DST_ADDR"][i]))
+            dst_node = int(trace["MAC_DST_ADDR"][i])
+            tx_energy = float(trace["TX_POWER"][i]) * TX_TIME
+            rx_energy = RX_POWER * TX_TIME
+            ts = round(float(trace["TS"][i]) / 1000000000.0, 2)   # turn to seconds
+
+            if unique_id not in packet_paths:
+                packet_paths[unique_id] = [[hop], dst_node, (tx_energy + rx_energy), ts, attempt_number]
+                attempt_number += 1
+            else:
+                packet_paths[unique_id][0].append(hop)
+                packet_paths[unique_id][2] += (tx_energy + rx_energy)
+
+    # Filter out the packets which have been lost during the transmission - the ones which didn't reach the destination node
+    packets_to_remove = []
+    for packet in packet_paths:
+        if packet_paths[packet][0][-1][1] != packet_paths[packet][1]:
+            packets_to_remove.append(packet)
+
+    for packet in packets_to_remove:
+        del packet_paths[packet]
+
+    # print packet_paths
+
+    # Store the information how many times a path has been chosen, and its energy consumption
+    path_stats = {} # format: {path: [times_used, energy, attempt_number]}
+    for packet in packet_paths:
+        path = tuple(packet_paths[packet][0])
+
+        if path not in path_stats:
+            path_stats[path] = [1, packet_paths[packet][2], packet_paths[packet][3], packet_paths[packet][4]]
+        else:
+            path_stats[path][0] += 1
+
+    # calculate percentage of the path usage
+    total_paths_number = 0
+    for path in path_stats:
+        total_paths_number += path_stats[path][0]
+
+    for path in path_stats:
+        path_stats[path][0] = round(100.0 * path_stats[path][0] / float(total_paths_number), 2)
+
+    # print path_stats
+    # Find converged path
+    max_usage_percentage = 0
+    converged_path = None
+    converged_attempts = 0
+    converge_time = 0
+    converged_path_energy = 0 
+    for path in path_stats:
+        if path_stats[path][0] > max_usage_percentage:
+            max_usage_percentage = path_stats[path][0]
+            converged_path = path
+            converged_attempts = path_stats[path][3]
+            converge_time = path_stats[path][2]
+            converged_path_energy = path_stats[path][1]
+
+    # print converged_path
+    # print converged_attempts
+    # print converge_time
+    # print converged_path_energy
+
+    # Check if the converged path is optimal or not
+    # Get optimal path from the text file
+    optimal_path_filename = "optimal_path-%s-%s" % (l, n_nodes)
+    with open(optimal_path_filename, "r") as f:
+        raw = f.readlines()
+
+        path_line = raw[-1].split("\t")[-1].split(" ")[:-1]
+
+        optimal_path = []
+        for node in path_line:
+            optimal_path.append(int(node) + 1)
+        
+        # print "energy:", raw[-1].split("\t")[-3]
+        optimal_path_energy = float(raw[-1].split("\t")[-3])
+
+    converged_path_formatted = []
+    for hop in converged_path:
+        converged_path_formatted.append(hop[0])
+    converged_path_formatted.append(hop[1])
+
+    # print optimal_path
+    # print converged_path_formatted
+    # print converged_path
+
+    if (optimal_path == converged_path_formatted):
+        isOptimal = 1
+    else:
+        isOptimal = 0
+
+    return converged_attempts, converge_time, isOptimal, converged_path_energy, optimal_path_energy
+
+# Print the results to a file
+def print_results():
+    # for n_nodes in NODES:
+    for l in LAMBDAS:
+
+        file_name = PRINT_FILENAME % l
+        if not os.path.exists(file_name):
+            f =open(file_name, "a")
+            # f.write("Density\tNodesNumber\tLambda\tTxPackets\tRxPackets\tTxCount\tRxCount\tCollisionCount\tTotalEnergyConsumption\tEnergyPerBit\tTotalThroughput\tPDR\tAvgHopCount\tAvgDelay\tConvergedAttempt\tConvergeTime\tIsOptimal?\tEnergyConsumptionConvergedPath\tEnergyConsumptionOptimalPath\tOptimalConvergedRatio\n")
+            f.write("Density\tNodesNumber\tLambda\tTxPackets\tRxPackets\tTxCount\tRxCount\tCollisionCount\tTotalEnergyConsumption\tEnergyPerBit\tTotalThroughput\tPDR\tAvgHopCount\n")
+
+        else:
+            f =open(file_name, "a")
+            
+        # line = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s"
+        line = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s"
+
+        # for l in LAMBDAS:
+        for n_nodes in NODES:
+
+            for metric in METRICS:
+                VALUES[metric] = []
+            x = []
+
+            events = trace_parser_libra.parse_events((TRACE_PATH + TRACE_NAME) % (l, n_nodes))
+            trace, node_info = trace_parser_libra.parse_fields(events)
+
+            # converged_attempts, converge_time, is_optimal, converged_path_energy, optimal_path_energy = get_converged_stats(trace, l, n_nodes)
+
+            # # Print results to file
+            # n_recv_packets = trace_parser_libra.calc_recv_packets(trace)
+            # total_energy = trace_parser_libra.calc_energy_consumption(node_info)
+            # data = (n_nodes/100., n_nodes, l, trace_parser_libra.calc_sent_packets(trace), n_recv_packets, 
+            # trace_parser_libra.calc_tx_calls(trace), trace_parser_libra.calc_rx_calls(trace), trace_parser_libra.calc_total_collisions(node_info), 
+            # round(total_energy, 2), round(float(total_energy) / (n_recv_packets * PACKET_SIZE * 8), 4), round(trace_parser_libra.calc_throughput(trace), 2),
+            # round(trace_parser_libra.calc_pdr(trace), 2), round(trace_parser_libra.calc_hop_count(trace), 2), round(trace_parser_libra.calc_delay(trace), 2), 
+            # converged_attempts, converge_time, is_optimal, round(converged_path_energy, 4), round(optimal_path_energy, 4), 
+            # round(optimal_path_energy/converged_path_energy, 4))
+
+            n_recv_packets = trace_parser_libra.calc_recv_packets(trace)
+            total_energy = trace_parser_libra.calc_energy_consumption(node_info)
+            data = (n_nodes/100., n_nodes, l, trace_parser_libra.calc_sent_packets(trace), n_recv_packets, 
+            trace_parser_libra.calc_tx_calls(trace), trace_parser_libra.calc_rx_calls(trace), trace_parser_libra.calc_total_collisions(node_info), 
+            round(total_energy, 2), round(float(total_energy) / (n_recv_packets * PACKET_SIZE * 8), 4), round(trace_parser_libra.calc_throughput(trace), 2),
+            round(trace_parser_libra.calc_pdr(trace), 2), round(trace_parser_libra.calc_hop_count(trace), 2))
+
+
+            f.write(line % data)
+            # f.write(str(trace_parser_libra.calc_hop_count(trace)))
+            f.write("\n")
+            f.flush()
+
+        f.close()
+
+
+def main():
+    print_results()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/print_results_sfama.py
+++ b/scripts/print_results_sfama.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+"""
+Plot the results, obtained from the trace files.
+"""
+
+
+import trace_parser_sfama
+import numpy
+
+import os.path
+
+
+PACKET_SIZE = 800
+# N_HOPS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25]
+# N_HOPS = [6, 7, 8, 9, 10]
+# N_HOPS = [0, 1]
+# N_HOPS = [0, 3, 5, 7, 10]
+# NODES = [50, 100, 150, 200, 250]
+# NODES = [25, 50, 75, 100, 125]
+# NODES = [64, 80, 96, 112, 128]
+NODES = [128]
+
+# LAMBDAS = ['0.01', '0.02', '0.03', '0.04', '0.05', '0.06', '0.07', '0.08', '0.09', '0.10']
+# LAMBDAS = ['0.01']
+# LAMBDAS = ['0.01', '0.20', '0.40', '0.60', '0.80', '1.00']
+LAMBDAS = ['0.01']
+# LAMBDAS = ['0.01', '0.05', '0.10', '0.15', '0.20', '0.25', '0.30', '0.35', '0.40', '0.45', '0.50', '0.55', '0.60']
+
+METRICS = ["collisions", "energy", "energy_per_bit", "throughput", "pdr", "hop_count"]
+# METRICS = ["hop_count"]
+METRICS_NAMES = {"collisions": "Total number of collisions", "energy": "Total energy consumption, Joules", "energy_per_bit": "Energy per Bit, Joules", "throughput": "Total network throughput, bps", 
+                "pdr": "Packet Delivery Ratio (PDR)", "hop_count": "Average Hop Count"}
+VALUES = {"collisions": [], "energy": [], "energy_per_bit": [], "throughput": [], "pdr": [], "hop_count": []}
+
+
+TRACE_PATH = "../../../"
+TRACE_NAME = "sfama-density-trace-%s-%s-0.asc"
+PRINT_FILENAME = "sfama-density-%s.txt" # insert number of nodes
+
+
+def get_converged_stats(trace, l, n_nodes):
+    TX_TIME = 800 * 8 / 10000.0    # packet_size * 8 / channel_bps
+    RX_POWER = 0.82     # Watts
+    
+    packet_paths = {}
+    attempt_number = 1
+    for i in range(len(trace["TS"])):
+        if trace["RX/TX-MODE"][i] == "TX" and trace["PTYPE"][i] == "SFAMA_DATA":
+            unique_id = trace["UNIQUE_ID"][i]
+            hop = (int(trace["MAC_SRC_ADDR"][i]), int(trace["MAC_DST_ADDR"][i]))
+            dst_node = int(trace["MAC_DST_ADDR"][i])
+            tx_energy = float(trace["TX_POWER"][i]) * TX_TIME
+            rx_energy = RX_POWER * TX_TIME
+            ts = round(float(trace["TS"][i]) / 1000000000.0, 2)   # turn to seconds
+
+            if unique_id not in packet_paths:
+                packet_paths[unique_id] = [[hop], dst_node, (tx_energy + rx_energy), ts, attempt_number]
+                attempt_number += 1
+            else:
+                packet_paths[unique_id][0].append(hop)
+                packet_paths[unique_id][2] += (tx_energy + rx_energy)
+
+    # Filter out the packets which have been lost during the transmission - the ones which didn't reach the destination node
+    packets_to_remove = []
+    for packet in packet_paths:
+        if packet_paths[packet][0][-1][1] != packet_paths[packet][1]:
+            packets_to_remove.append(packet)
+
+    for packet in packets_to_remove:
+        del packet_paths[packet]
+
+    # print packet_paths
+
+    # Store the information how many times a path has been chosen, and its energy consumption
+    path_stats = {} # format: {path: [times_used, energy, attempt_number]}
+    for packet in packet_paths:
+        path = tuple(packet_paths[packet][0])
+
+        if path not in path_stats:
+            path_stats[path] = [1, packet_paths[packet][2], packet_paths[packet][3], packet_paths[packet][4]]
+        else:
+            path_stats[path][0] += 1
+
+    # calculate percentage of the path usage
+    total_paths_number = 0
+    for path in path_stats:
+        total_paths_number += path_stats[path][0]
+
+    for path in path_stats:
+        path_stats[path][0] = round(100.0 * path_stats[path][0] / float(total_paths_number), 2)
+
+    # print path_stats
+    # Find converged path
+    max_usage_percentage = 0
+    converged_path = None
+    converged_attempts = 0
+    converge_time = 0
+    converged_path_energy = 0 
+    for path in path_stats:
+        if path_stats[path][0] > max_usage_percentage:
+            max_usage_percentage = path_stats[path][0]
+            converged_path = path
+            converged_attempts = path_stats[path][3]
+            converge_time = path_stats[path][2]
+            converged_path_energy = path_stats[path][1]
+
+    # print converged_path
+    # print converged_attempts
+    # print converge_time
+    # print converged_path_energy
+
+    # Check if the converged path is optimal or not
+    # Get optimal path from the text file
+    optimal_path_filename = "optimal_path-%s-%s" % (l, n_nodes)
+    with open(optimal_path_filename, "r") as f:
+        raw = f.readlines()
+
+        path_line = raw[-1].split("\t")[-1].split(" ")[:-1]
+
+        optimal_path = []
+        for node in path_line:
+            optimal_path.append(int(node) + 1)
+        
+        # print "energy:", raw[-1].split("\t")[-3]
+        optimal_path_energy = float(raw[-1].split("\t")[-3])
+
+    converged_path_formatted = []
+    for hop in converged_path:
+        converged_path_formatted.append(hop[0])
+    converged_path_formatted.append(hop[1])
+
+    # print optimal_path
+    # print converged_path_formatted
+    # print converged_path
+
+    if (optimal_path == converged_path_formatted):
+        isOptimal = 1
+    else:
+        isOptimal = 0
+
+    return converged_attempts, converge_time, isOptimal, converged_path_energy, optimal_path_energy
+
+# Print the results to a file
+def print_results():
+    # for n_nodes in NODES:
+    for l in LAMBDAS:
+
+        file_name = PRINT_FILENAME % l
+        if not os.path.exists(file_name):
+            f =open(file_name, "a")
+            # f.write("Density\tNodesNumber\tLambda\tTxPackets\tRxPackets\tTxCount\tRxCount\tCollisionCount\tTotalEnergyConsumption\tEnergyPerBit\tTotalThroughput\tPDR\tAvgHopCount\tAvgDelay\tConvergedAttempt\tConvergeTime\tIsOptimal?\tEnergyConsumptionConvergedPath\tEnergyConsumptionOptimalPath\tOptimalConvergedRatio\n")
+            f.write("Density\tNodesNumber\tLambda\tTxPackets\tRxPackets\tTxCount\tRxCount\tCollisionCount\tTotalEnergyConsumption\tEnergyPerBit\tTotalThroughput\tPDR\n")
+
+        else:
+            f =open(file_name, "a")
+            
+        # line = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s"
+        line = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s"
+
+        # for l in LAMBDAS:
+        for n_nodes in NODES:
+
+            for metric in METRICS:
+                VALUES[metric] = []
+            x = []
+
+            events = trace_parser_sfama.parse_events((TRACE_PATH + TRACE_NAME) % (l, n_nodes))
+            trace, node_info = trace_parser_sfama.parse_fields(events)
+
+            # converged_attempts, converge_time, is_optimal, converged_path_energy, optimal_path_energy = get_converged_stats(trace, l, n_nodes)
+
+            # # Print results to file
+            # n_recv_packets = trace_parser_sfama.calc_recv_packets(trace)
+            # total_energy = trace_parser_sfama.calc_energy_consumption(node_info)
+            # data = (n_nodes/100., n_nodes, l, trace_parser_sfama.calc_sent_packets(trace), n_recv_packets, 
+            # trace_parser_sfama.calc_tx_calls(trace), trace_parser_sfama.calc_rx_calls(trace), trace_parser_sfama.calc_total_collisions(node_info), 
+            # round(total_energy, 2), round(float(total_energy) / (n_recv_packets * PACKET_SIZE * 8), 4), round(trace_parser_sfama.calc_throughput(trace), 2),
+            # round(trace_parser_sfama.calc_pdr(trace), 2), round(trace_parser_sfama.calc_hop_count(trace), 2), round(trace_parser_sfama.calc_delay(trace), 2), 
+            # converged_attempts, converge_time, is_optimal, round(converged_path_energy, 4), round(optimal_path_energy, 4), 
+            # round(optimal_path_energy/converged_path_energy, 4))
+
+            n_recv_packets = trace_parser_sfama.calc_recv_packets(trace)
+            total_energy = trace_parser_sfama.calc_energy_consumption(node_info)
+            data = (n_nodes/100., n_nodes, l, trace_parser_sfama.calc_sent_packets(trace), n_recv_packets, 
+            trace_parser_sfama.calc_tx_calls(trace), trace_parser_sfama.calc_rx_calls(trace), trace_parser_sfama.calc_total_collisions(node_info), 
+            round(total_energy, 2), round(float(total_energy) / (n_recv_packets * PACKET_SIZE * 8), 4), round(trace_parser_sfama.calc_throughput(trace), 2),
+            round(trace_parser_sfama.calc_pdr(trace), 2))
+
+
+            f.write(line % data)
+            # f.write(str(trace_parser_sfama.calc_hop_count(trace)))
+            f.write("\n")
+            f.flush()
+
+        f.close()
+
+
+def main():
+    print_results()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/trace_parser_aloha.py
+++ b/scripts/trace_parser_aloha.py
@@ -1,0 +1,330 @@
+#!/usr/bin/python
+"""
+Parse ALOHA ascii trace file from NS-3 Aqua-Sim to extract results from simulation.
+"""
+
+
+import sys
+import numpy
+
+
+# Energy-related pararmeters
+TX_POWER = 60.0     # Watts
+RX_POWER = 0.158     # Watts
+IDLE_POWER = 0.158   # Watts
+LINK_SPEED = 10000.0  # bps
+
+
+# Parse trace file to tx/rx events
+def parse_events(trace_file_path):
+    # Store raw tx/rx events, parsed from the original trace file
+    EVENTS = []
+
+    with open(trace_file_path, "r") as f:
+        # Store tx/rx event list
+        event = ""
+        i = 0
+        for line in f:
+
+            if (line[0] == "t" or line[0] =="r") and (i != 0):
+
+                EVENTS.append(event)
+
+                event = line[:-1]
+
+            else:
+                event += line[:-1]
+
+            i += 1
+
+        EVENTS.append(event)
+    return EVENTS
+
+
+def print_events(EVENTS):
+    for event in EVENTS:
+        print (event)
+        print ("")
+
+
+def parse_fields(EVENTS):
+    # TRACE object with parsed fields
+    TRACE = {"RX/TX-MODE": [], "TS": [], "NODE_ID": [], "TX_POWER": [], "RX_POWER": [], "TX_TIME": [], "DIRECTION": [],
+    "NUM_FORWARDS": [], "ERROR": [], "UNIQUE_ID": [], "PTYPE": [], "PAYLOAD_SIZE": [], "MAC_SRC_ADDR": [], "MAC_DST_ADDR": []}
+
+    # Store per Node information: number of processed RX events, number of collisions
+    NODE_VALUES = {"PROCESSED_RX_COUNT": 0, "RX_ENERGY": 0.0, "TX_ENERGY": 0.0, "IDLE_ENERGY": 0.0, "COLLISION_COUNT": 0, "LAST_TS": 0.0}
+    #NODE_INFO = {"NODE_ID": {"PROCESSED_RX_COUNT": 0, "RX_ENERGY": 0.0, "TX_ENERGY": 0.0, "IDLE_ENERGY": 0.0, "COLLISION_COUNT": 0, "LAST_TS": 0.0}}
+    NODE_INFO = {}
+    for i in range(300):
+        NODE_INFO[i] = dict(NODE_VALUES)
+
+    # Parse the fields
+    for line in EVENTS:
+
+        stripped_line = line.split(" ")
+        if line[0] == "t":
+            ptype = stripped_line[38].split("=")[1][:-1]
+            TRACE["PTYPE"].append(ptype)
+            TRACE["RX/TX-MODE"].append("TX")
+            ts = float(stripped_line[1])
+            TRACE["TS"].append(ts)
+            node_id = int(stripped_line[2].split("/")[2])
+            TRACE["NODE_ID"].append(node_id)
+
+            TRACE["TX_POWER"].append(TX_POWER)
+            TRACE["PAYLOAD_SIZE"].append(int(stripped_line[55].split("=")[1][:-1]))
+
+            TRACE["RX_POWER"].append(0)
+            TRACE["TX_TIME"].append(float(stripped_line[16].split("=")[1][1:-2]))
+            
+            TRACE["DIRECTION"].append(stripped_line[18].split("=")[1])
+            TRACE["NUM_FORWARDS"].append(int(stripped_line[19].split("=")[1]))
+            TRACE["ERROR"].append(stripped_line[20].split("=")[1])
+            TRACE["UNIQUE_ID"].append(int(stripped_line[21].split("=")[1]))
+
+            TRACE["MAC_SRC_ADDR"].append(stripped_line[23].split("=")[1])
+            TRACE["MAC_DST_ADDR"].append(stripped_line[24].split("=")[1])
+
+            # Update node info
+            # We need to add the IDLE power to TX power (node can't consume less than IDLE energy when in TX)
+            header_size = int(stripped_line[55].split("=")[1][:-1])
+            NODE_INFO[node_id]["TX_ENERGY"] += ((header_size * 8) / LINK_SPEED) * TX_POWER
+            NODE_INFO[node_id]["TX_ENERGY"] += ((header_size * 8) / LINK_SPEED) * IDLE_POWER
+            if ts >= NODE_INFO[node_id]["LAST_TS"]:
+                NODE_INFO[node_id]["IDLE_ENERGY"] += ((ts - NODE_INFO[node_id]["LAST_TS"]) / 1000000000.0) * IDLE_POWER
+                NODE_INFO[node_id]["LAST_TS"] = ts + ((header_size * 8) / LINK_SPEED) * 1000000000.0
+                # print header_size
+            else:
+                NODE_INFO[node_id]["COLLISION_COUNT"] += 1
+                # print "TX", node_id, header_size, ts, "<--->", NODE_INFO[node_id]["LAST_TS"]
+
+
+        elif line[0] == "r":
+            ptype = stripped_line[30].split("=")[1][:-1]
+            TRACE["PTYPE"].append(ptype)
+            TRACE["RX/TX-MODE"].append("RX")
+            ts = float(stripped_line[1])
+            TRACE["TS"].append(ts)
+            node_id = int(stripped_line[2].split("/")[2])
+            TRACE["NODE_ID"].append(node_id)
+
+            TRACE["TX_POWER"].append(TX_POWER)
+            TRACE["PAYLOAD_SIZE"].append(int(stripped_line[47].split("=")[1][:-1]))
+
+            TRACE["RX_POWER"].append(0)
+            TRACE["TX_TIME"].append(0)
+
+            TRACE["DIRECTION"].append(stripped_line[10].split("=")[1])
+            TRACE["NUM_FORWARDS"].append(int(stripped_line[11].split("=")[1]))
+            TRACE["ERROR"].append(stripped_line[12].split("=")[1])
+            TRACE["UNIQUE_ID"].append(int(stripped_line[13].split("=")[1]))
+
+            TRACE["MAC_SRC_ADDR"].append(stripped_line[15].split("=")[1])
+            TRACE["MAC_DST_ADDR"].append(stripped_line[16].split("=")[1])
+
+            # Update node info
+            # if (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0) > NODE_INFO[node_id]["LAST_TS"]:
+            header_size = int(stripped_line[47].split("=")[1][:-1])
+            if (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0) >= NODE_INFO[node_id]["LAST_TS"]:
+                NODE_INFO[node_id]["PROCESSED_RX_COUNT"] += 1
+                NODE_INFO[node_id]["IDLE_ENERGY"] += ((ts - NODE_INFO[node_id]["LAST_TS"]) / 1000000000.0) * IDLE_POWER
+                # print header_size
+                # NODE_INFO[node_id]["LAST_TS"] = ts + ((header_size * 8) / LINK_SPEED) * 1000000000.0
+                # NODE_INFO[node_id]["LAST_TS"] = ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0    # Rx event is traced at the end of reception, therefore, we need to find the beginning of Rx
+                NODE_INFO[node_id]["LAST_TS"] = ts
+                NODE_INFO[node_id]["RX_ENERGY"] += ((header_size * 8) / LINK_SPEED) * RX_POWER
+            else:
+                NODE_INFO[node_id]["COLLISION_COUNT"] += 1
+                # print "RX", node_id, header_size, (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0), "<--->", NODE_INFO[node_id]["LAST_TS"]
+                # print (NODE_INFO[node_id]["LAST_TS"] - (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0)) / 1000000000.
+
+    return TRACE, NODE_INFO
+
+
+# Print the parsed trace object
+def print_trace(TRACE):
+    for field in TRACE:
+        print("%s :" % field, TRACE[field])
+        print(len(TRACE[field]))
+        print("")
+
+
+# Calculate number of packets, received by MAC layer AND sent up to the upper layers
+def calc_recv_packets(TRACE):
+    num_recv_packets = 0
+    processed_ids = []
+
+    # Go through the dictionary and find the packets, which MAC_DST_ADDR matches the address of the node.
+    # Also, ignore duplicate receptions (if any) by checking UNIQUE_ID field
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            num_recv_packets += 1
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+
+    return num_recv_packets
+
+
+# Calculate number of actual hops a received packet has traversed (avg hop count)
+def calc_hop_count(TRACE):
+    return 1.0
+
+
+# Calculate average end-to-end delay
+def calc_delay(TRACE):
+    delays = []
+    processed_ids = []
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            # Find the timestamp when this packet were initially sent
+            for j in range(len(TRACE["TS"])):
+                if (TRACE["UNIQUE_ID"][i] == TRACE["UNIQUE_ID"][j] and TRACE["RX/TX-MODE"][j] == "TX"):
+
+                    delays.append((TRACE["TS"][i] - TRACE["TS"][j]) / 1000000000.) # to Seconds
+
+
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+
+    return numpy.array(delays).mean()
+
+
+# Calculate "instantaneous" throuhgput - number of bits received over a second
+def calc_isntantaneous_throughput(TRACE):
+    processed_ids = []
+    # Find the fisrt starting ts
+    start_ts = 0.0
+    num_recv_packets = 0
+    timestamps = []
+    throughputs = []
+    moving_average = []
+    previous_average = 0.0
+    k = 1
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            start_ts = float(TRACE["TS"][i])
+            num_recv_packets += 1
+            break
+
+    # Go through the dictionary and find the packets, which MAC_DST_ADDR matches the address of the node.
+    # Also, ignore duplicate receptions (if any) by checking UNIQUE_ID field
+    for i in range(1, len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+            if (float(TRACE["TS"][i] - start_ts)) < 10000000000.0: # if the time difference between current ts and starting ts is less than 10 seconds
+                num_recv_packets += 1
+            
+            else:
+                timestamps.append(float(TRACE["TS"][i] / 1000000000.0))
+                current_throughput = (num_recv_packets * PACKET_SIZE * 8) / ((float(TRACE["TS"][i]) - start_ts) / 1000000000.0)
+                throughputs.append(current_throughput)
+                current_average = previous_average + (current_throughput - previous_average) / k
+                moving_average.append(current_average)
+                previous_average = current_average
+                k += 1
+                # inst_throuhgput[float(TRACE["TS"][i] / 1000000000.0)] = (num_recv_packets * PACKET_SIZE * 8) / ((float(TRACE["TS"][i]) - start_ts) / 1000000000.0) # bits
+                start_ts = float(TRACE["TS"][i])
+                num_recv_packets = 1
+
+    return (timestamps, throughputs, moving_average)
+
+
+# Calculate number of packets, sent by the source node (not counting the relays)
+def calc_sent_packets(TRACE):
+    num_sent_packets = 0
+    processed_ids = []
+
+    # Go through the dictionary and find the packets, which MAC_SRC_ADDR mathes the address of the node.
+    # Also, ignore duplicate receptions (if any) by checking UNIQUE_ID field
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_SRC_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            num_sent_packets += 1
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+
+    return num_sent_packets
+
+
+# Calculate total number of TX events
+def calc_tx_calls(TRACE):
+    return TRACE["RX/TX-MODE"].count("TX")
+
+
+# Calculate total number of RX events
+def calc_rx_calls(TRACE):
+    return TRACE["RX/TX-MODE"].count("RX")
+
+
+# Calculate total energy consumption
+def calc_energy_consumption(NODE_INFO):
+    total_energy = 0.0
+
+    # print NODE_INFO
+    for node in NODE_INFO:
+        total_energy += NODE_INFO[node]["RX_ENERGY"]
+    	# print "RX_ENERGY: ", NODE_INFO[node]["RX_ENERGY"]
+        total_energy += NODE_INFO[node]["TX_ENERGY"]
+        # print "TX_ENERGY: ", NODE_INFO[node]["TX_ENERGY"]
+        total_energy += NODE_INFO[node]["IDLE_ENERGY"]
+        # print "IDLE_ENERGY: ", NODE_INFO[node]["IDLE_ENERGY"]
+
+    # print total_energy
+    return total_energy
+
+
+PACKET_SIZE = 800 # bytes
+# Calculate energy per bit (received bit)
+def calc_energy_per_bit(NODE_INFO, TRACE):
+    total_energy = calc_energy_consumption(NODE_INFO)
+    return total_energy / (calc_recv_packets(TRACE) * PACKET_SIZE * 8)
+
+
+# Calculate total number of collisionis from all nodes
+def calc_total_collisions(NODE_INFO):
+    collision_count = 0
+    for node in NODE_INFO:
+        collision_count += NODE_INFO[node]["COLLISION_COUNT"]
+
+    return collision_count
+
+
+# Throughput calculation
+def calc_throughput(TRACE):
+    n_recv_packets = calc_recv_packets(TRACE)
+    throughput = (n_recv_packets * 8 * TRACE["PAYLOAD_SIZE"][0]) / ((TRACE["TS"][-1] / 1000000000.0))
+    return throughput
+
+
+# PDR
+def calc_pdr(TRACE):
+    n_recv_packets = calc_recv_packets(TRACE)
+    n_sent_packets = calc_sent_packets(TRACE)
+    pdr = (float(n_recv_packets) / n_sent_packets)
+    return pdr
+
+
+def main():
+    # Parse the trace file to a list of tx/rx events
+    TRACE_FILE_PATH = sys.argv[1]
+    EVENTS = parse_events(TRACE_FILE_PATH)
+    # print_events()
+    TRACE, NODE_INFO = parse_fields(EVENTS)
+    # print_trace()
+
+    # Calculate number of sent and recevied packets
+    n_recv_packets = calc_recv_packets(TRACE)
+    print ("Number of received packets: ", n_recv_packets)
+    n_sent_packets = calc_sent_packets(TRACE)
+    print ("Number of sent packets: ", n_sent_packets)
+    print ("Total number of tx calls: ", calc_tx_calls(TRACE))
+    print ("Total number of rx calls: ", calc_rx_calls(TRACE))
+    print ("Total energy consumption: ", calc_energy_consumption(NODE_INFO))
+    print ("Energy per bit: ", calc_energy_per_bit(NODE_INFO, TRACE))
+    print ("Throughput: ", calc_throughput(TRACE))
+    # print ("Throughput per node: ", (n_recv_packets * 8 * TRACE["PAYLOAD_SIZE"][0]) / ((max(TRACE["NODE_ID"]) + 1) * (TRACE["TS"][-1] / 1000000000.0)))
+    print ("PDR: ", float(n_recv_packets) / n_sent_packets)
+    print ("Number of collisions: ", calc_total_collisions(NODE_INFO))
+    print ("Instantaneous throuhgput: ", calc_isntantaneous_throughput(TRACE))
+    print ("Average hop count: ", calc_hop_count(TRACE))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/trace_parser_libra.py
+++ b/scripts/trace_parser_libra.py
@@ -1,0 +1,392 @@
+#!/usr/bin/python
+"""
+Parse ascii trace file from NS-3 Aqua-Sim to extract results from simulation.
+"""
+
+
+import sys
+import numpy
+
+
+# Energy-related pararmeters
+RX_POWER = 0.158     # Watts
+IDLE_POWER = 0.158   # Watts
+LINK_SPEED = 10000.0  # bps
+
+
+# Parse trace file to tx/rx events
+def parse_events(trace_file_path):
+    # Store raw tx/rx events, parsed from the original trace file
+    EVENTS = []
+
+    with open(trace_file_path, "r") as f:
+        # Store tx/rx event list
+        event = ""
+        i = 0
+        for line in f:
+
+            if (line[0] == "t" or line[0] =="r") and (i != 0):
+
+                EVENTS.append(event)
+
+                event = line[:-1]
+
+            else:
+                event += line[:-1]
+
+            i += 1
+
+        EVENTS.append(event)
+    return EVENTS
+
+
+def print_events(EVENTS):
+    for event in EVENTS:
+        print (event)
+        print ("")
+
+
+def parse_fields(EVENTS):
+    # TRACE object with parsed fields
+    TRACE = {"RX/TX-MODE": [], "TS": [], "NODE_ID": [], "TX_POWER": [], "TX_RANGE": [], "RX_POWER": [], "TX_TIME": [], "HEADER_SIZE": [],  "DIRECTION": [],
+    "NUM_FORWARDS": [], "ERROR": [], "UNIQUE_ID": [], "SENDER_ADDR": [], "SRC_ADDR": [], "DST_ADDR": [], "DIRECT_DISTANCE": [], "PTYPE": [],
+    "HOP_COUNT": [], "REWARD": [], "PAYLOAD_SIZE": [], "NEXT_HOP_DISTANCE": [], "XMAC_HEADER_ID": [], "OPTIMAL_DISTANCE": [], "MAX_HOPS_NUMBER": [],
+    "MAC_SRC_ADDR": [], "MAC_DST_ADDR": []}
+
+    # Store per Node information: number of processed RX events, number of collisions
+    NODE_VALUES = {"PROCESSED_RX_COUNT": 0, "RX_ENERGY": 0.0, "TX_ENERGY": 0.0, "IDLE_ENERGY": 0.0, "COLLISION_COUNT": 0, "LAST_TS": 0.0}
+    #NODE_INFO = {"NODE_ID": {"PROCESSED_RX_COUNT": 0, "RX_ENERGY": 0.0, "TX_ENERGY": 0.0, "IDLE_ENERGY": 0.0, "COLLISION_COUNT": 0, "LAST_TS": 0.0}}
+    NODE_INFO = {}
+    for i in range(300):
+        NODE_INFO[i] = dict(NODE_VALUES)
+
+    # Parse the fields
+    for line in EVENTS:
+
+        stripped_line = line.split(" ")
+        if line[0] == "t":
+            ptype = int(stripped_line[36].split("=")[1])
+            TRACE["PTYPE"].append(ptype)
+            TRACE["RX/TX-MODE"].append("TX")
+            ts = float(stripped_line[1])
+            TRACE["TS"].append(ts)
+            node_id = int(stripped_line[2].split("/")[2])
+            TRACE["NODE_ID"].append(node_id)
+            TRACE["XMAC_HEADER_ID"].append(int(stripped_line[37].split("=")[1]))
+
+            if ptype == 0:
+                tx_power = float(stripped_line[44].split("=")[1])
+                TRACE["TX_POWER"].append(tx_power)
+                TRACE["SENDER_ADDR"].append(stripped_line[40].split("=")[1])
+                TRACE["SRC_ADDR"].append(stripped_line[41].split("=")[1])
+                TRACE["DST_ADDR"].append(stripped_line[42].split("=")[1])
+                TRACE["DIRECT_DISTANCE"].append(float(stripped_line[43].split("=")[1]))
+                TRACE["HOP_COUNT"].append(int(stripped_line[38].split("=")[1]))
+                TRACE["REWARD"].append(float(stripped_line[39].split("=")[1]))
+                # if stripped_line[66].split("=")[1][:-1] != "800":
+                #     print stripped_line[66].split("=")[1][:-1]
+                TRACE["PAYLOAD_SIZE"].append(int(stripped_line[66].split("=")[1][:-1]))
+                TRACE["NEXT_HOP_DISTANCE"].append(float(stripped_line[46].split("=")[1]))
+                TRACE["OPTIMAL_DISTANCE"].append(float(stripped_line[47].split("=")[1]))
+                TRACE["MAX_HOPS_NUMBER"].append(int(stripped_line[48].split("=")[1]))
+
+            elif ptype == 7:
+                tx_power = float(stripped_line[41].split("=")[1])
+                TRACE["TX_POWER"].append(tx_power)
+                TRACE["SENDER_ADDR"].append(stripped_line[38].split("=")[1])
+                TRACE["SRC_ADDR"].append(stripped_line[38].split("=")[1])
+                TRACE["DST_ADDR"].append(stripped_line[39].split("=")[1])
+                TRACE["DIRECT_DISTANCE"].append(0)
+                TRACE["HOP_COUNT"].append(0)
+                TRACE["REWARD"].append(float(stripped_line[40].split("=")[1]))
+                TRACE["PAYLOAD_SIZE"].append(0)
+                TRACE["NEXT_HOP_DISTANCE"].append(float(stripped_line[43].split("=")[1]))
+                TRACE["OPTIMAL_DISTANCE"].append(0)
+                TRACE["MAX_HOPS_NUMBER"].append(0)
+
+            TRACE["TX_RANGE"].append(float(stripped_line[7].split('(')[1][:-1]))
+            TRACE["RX_POWER"].append(0)
+            TRACE["TX_TIME"].append(float(stripped_line[16].split("=")[1][1:-2]))
+            header_size = int(stripped_line[17].split("=")[1])
+            TRACE["HEADER_SIZE"].append(header_size)
+            TRACE["DIRECTION"].append(stripped_line[18].split("=")[1])
+            TRACE["NUM_FORWARDS"].append(int(stripped_line[19].split("=")[1]))
+            TRACE["ERROR"].append(stripped_line[20].split("=")[1])
+            TRACE["UNIQUE_ID"].append(int(stripped_line[21].split("=")[1]))
+            TRACE["MAC_SRC_ADDR"].append(stripped_line[23].split("=")[1])
+            TRACE["MAC_DST_ADDR"].append(stripped_line[24].split("=")[1])
+
+            # Update node info
+            # We need to add the IDLE power to TX power (node can't consume less than IDLE energy when in TX)
+            NODE_INFO[node_id]["TX_ENERGY"] += ((header_size * 8) / LINK_SPEED) * tx_power
+            NODE_INFO[node_id]["TX_ENERGY"] += ((header_size * 8) / LINK_SPEED) * IDLE_POWER
+            if ts >= NODE_INFO[node_id]["LAST_TS"]:
+                NODE_INFO[node_id]["IDLE_ENERGY"] += ((ts - NODE_INFO[node_id]["LAST_TS"]) / 1000000000.0) * IDLE_POWER
+                NODE_INFO[node_id]["LAST_TS"] = ts + ((header_size * 8) / LINK_SPEED) * 1000000000.0
+                # print header_size
+            else:
+                NODE_INFO[node_id]["COLLISION_COUNT"] += 1
+                # print "TX", node_id, header_size, ts, "<--->", NODE_INFO[node_id]["LAST_TS"]
+
+
+        elif line[0] == "r":
+            ptype = int(stripped_line[28].split("=")[1])
+            TRACE["PTYPE"].append(ptype)
+            TRACE["RX/TX-MODE"].append("RX")
+            ts = float(stripped_line[1])
+            TRACE["TS"].append(ts)
+            node_id = int(stripped_line[2].split("/")[2])
+            TRACE["NODE_ID"].append(node_id)
+            TRACE["XMAC_HEADER_ID"].append(int(stripped_line[29].split("=")[1]))
+
+            if ptype == 0:
+                TRACE["TX_POWER"].append(float(stripped_line[36].split("=")[1]))
+                TRACE["SENDER_ADDR"].append(stripped_line[32].split("=")[1])
+                TRACE["SRC_ADDR"].append(stripped_line[33].split("=")[1])
+                TRACE["DST_ADDR"].append(stripped_line[34].split("=")[1])
+                TRACE["DIRECT_DISTANCE"].append(float(stripped_line[35].split("=")[1]))
+                TRACE["HOP_COUNT"].append(int(stripped_line[30].split("=")[1]))
+                TRACE["REWARD"].append(float(stripped_line[31].split("=")[1]))
+                TRACE["PAYLOAD_SIZE"].append(int(stripped_line[58].split("=")[1][:-1]))
+                TRACE["NEXT_HOP_DISTANCE"].append(float(stripped_line[38].split("=")[1]))
+                TRACE["OPTIMAL_DISTANCE"].append(float(stripped_line[39].split("=")[1]))
+                TRACE["MAX_HOPS_NUMBER"].append(int(stripped_line[40].split("=")[1]))
+
+            elif ptype == 7:
+                TRACE["TX_POWER"].append(float(stripped_line[33].split("=")[1]))
+                TRACE["SENDER_ADDR"].append(stripped_line[30].split("=")[1])
+                TRACE["SRC_ADDR"].append(stripped_line[30].split("=")[1])
+                TRACE["DST_ADDR"].append(stripped_line[31].split("=")[1])
+                TRACE["DIRECT_DISTANCE"].append(0)
+                TRACE["HOP_COUNT"].append(0)
+                TRACE["REWARD"].append(float(stripped_line[32].split("=")[1]))
+                TRACE["PAYLOAD_SIZE"].append(0)
+                TRACE["NEXT_HOP_DISTANCE"].append(float(stripped_line[35].split("=")[1]))
+                TRACE["OPTIMAL_DISTANCE"].append(0)
+                TRACE["MAX_HOPS_NUMBER"].append(0)
+
+
+            TRACE["TX_RANGE"].append(0)
+            TRACE["RX_POWER"].append(0)
+            TRACE["TX_TIME"].append(0)
+            header_size = int(stripped_line[9].split("=")[1])
+            TRACE["HEADER_SIZE"].append(header_size)
+            TRACE["DIRECTION"].append(stripped_line[10].split("=")[1])
+            TRACE["NUM_FORWARDS"].append(int(stripped_line[11].split("=")[1]))
+            TRACE["ERROR"].append(stripped_line[12].split("=")[1])
+            TRACE["UNIQUE_ID"].append(int(stripped_line[13].split("=")[1]))
+            TRACE["MAC_SRC_ADDR"].append(stripped_line[15].split("=")[1])
+            TRACE["MAC_DST_ADDR"].append(stripped_line[16].split("=")[1])
+
+            # Update node info
+            # if (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0) > NODE_INFO[node_id]["LAST_TS"]:
+            if (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0) >= NODE_INFO[node_id]["LAST_TS"]:
+                NODE_INFO[node_id]["PROCESSED_RX_COUNT"] += 1
+                NODE_INFO[node_id]["IDLE_ENERGY"] += ((ts - NODE_INFO[node_id]["LAST_TS"]) / 1000000000.0) * IDLE_POWER
+                # print header_size
+                # NODE_INFO[node_id]["LAST_TS"] = ts + ((header_size * 8) / LINK_SPEED) * 1000000000.0
+                # NODE_INFO[node_id]["LAST_TS"] = ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0    # Rx event is traced at the end of reception, therefore, we need to find the beginning of Rx
+                NODE_INFO[node_id]["LAST_TS"] = ts
+                NODE_INFO[node_id]["RX_ENERGY"] += ((header_size * 8) / LINK_SPEED) * RX_POWER
+            else:
+                NODE_INFO[node_id]["COLLISION_COUNT"] += 1
+                # print "RX", node_id, header_size, (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0), "<--->", NODE_INFO[node_id]["LAST_TS"]
+                # print (NODE_INFO[node_id]["LAST_TS"] - (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0)) / 1000000000.
+
+    return TRACE, NODE_INFO
+
+
+# Print the parsed trace object
+def print_trace(TRACE):
+    for field in TRACE:
+        print ("%s :" % field, TRACE[field])
+        print (len(TRACE[field]))
+        print ("")
+
+
+# Calculate number of packets, received by MAC layer AND sent up to the upper layers
+def calc_recv_packets(TRACE):
+    num_recv_packets = 0
+    processed_ids = []
+
+    # Go through the dictionary and find the packets, which DST_ADDR matches the address of the node.
+    # Also, ignore duplicate receptions (if any) by checking UNIQUE_ID field
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            num_recv_packets += 1
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+
+    return num_recv_packets
+
+
+# Calculate number of actual hops a received packet has traversed (avg hop count)
+def calc_hop_count(TRACE):
+    hop_counts = []
+    processed_ids = []
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            hop_counts.append(int(TRACE["HOP_COUNT"][i]))
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+
+    return numpy.array(hop_counts).mean()
+
+
+# Calculate average end-to-end delay
+def calc_delay(TRACE):
+    delays = []
+    processed_ids = []
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            # Find the timestamp when this packet were initially sent
+            for j in range(len(TRACE["TS"])):
+                if (TRACE["UNIQUE_ID"][i] == TRACE["UNIQUE_ID"][j] and TRACE["SENDER_ADDR"][i] == TRACE["SENDER_ADDR"][j] and 
+                    TRACE["RX/TX-MODE"][j] == "TX" and TRACE["PTYPE"][j] == 0):
+
+                    delays.append((TRACE["TS"][i] - TRACE["TS"][j]) / 1000000000.) # to Seconds
+
+
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+
+    return numpy.array(delays).mean()
+
+
+# Calculate "instantaneous" throuhgput - number of bits received over a second
+def calc_isntantaneous_throughput(TRACE):
+    processed_ids = []
+    # Find the fisrt starting ts
+    start_ts = 0.0
+    num_recv_packets = 0
+    timestamps = []
+    throughputs = []
+    moving_average = []
+    previous_average = 0.0
+    k = 1
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            start_ts = float(TRACE["TS"][i])
+            num_recv_packets += 1
+            break
+
+    # Go through the dictionary and find the packets, which DST_ADDR matches the address of the node.
+    # Also, ignore duplicate receptions (if any) by checking UNIQUE_ID field
+    for i in range(1, len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+            if (float(TRACE["TS"][i] - start_ts)) < 10000000000.0: # if the time difference between current ts and starting ts is less than 10 seconds
+                num_recv_packets += 1
+            
+            else:
+                timestamps.append(float(TRACE["TS"][i] / 1000000000.0))
+                current_throughput = (num_recv_packets * PACKET_SIZE * 8) / ((float(TRACE["TS"][i]) - start_ts) / 1000000000.0)
+                throughputs.append(current_throughput)
+                current_average = previous_average + (current_throughput - previous_average) / k
+                moving_average.append(current_average)
+                previous_average = current_average
+                k += 1
+                # inst_throuhgput[float(TRACE["TS"][i] / 1000000000.0)] = (num_recv_packets * PACKET_SIZE * 8) / ((float(TRACE["TS"][i]) - start_ts) / 1000000000.0) # bits
+                start_ts = float(TRACE["TS"][i])
+                num_recv_packets = 1
+
+    return (timestamps, throughputs, moving_average)
+
+
+# Calculate number of packets, sent by the source node (not counting the relays)
+def calc_sent_packets(TRACE):
+    num_sent_packets = 0
+    processed_ids = []
+
+    # Go through the dictionary and find the packets, which SRC_ADDR mathes the address of the node.
+    # Also, ignore duplicate receptions (if any) by checking UNIQUE_ID field
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_SRC_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids):
+            num_sent_packets += 1
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+
+    return num_sent_packets
+
+
+# Calculate total number of TX events
+def calc_tx_calls(TRACE):
+    return TRACE["RX/TX-MODE"].count("TX")
+
+
+# Calculate total number of RX events
+def calc_rx_calls(TRACE):
+    return TRACE["RX/TX-MODE"].count("RX")
+
+
+# Calculate total energy consumption
+def calc_energy_consumption(NODE_INFO):
+    total_energy = 0.0
+
+    # print NODE_INFO
+    for node in NODE_INFO:
+        total_energy += NODE_INFO[node]["RX_ENERGY"]
+    	# print "RX_ENERGY: ", NODE_INFO[node]["RX_ENERGY"]
+        total_energy += NODE_INFO[node]["TX_ENERGY"]
+        # print "TX_ENERGY: ", NODE_INFO[node]["TX_ENERGY"]
+        total_energy += NODE_INFO[node]["IDLE_ENERGY"]
+        # print "IDLE_ENERGY: ", NODE_INFO[node]["IDLE_ENERGY"]
+
+    # print total_energy
+    return total_energy
+
+
+PACKET_SIZE = 800 # bytes
+# Calculate energy per bit (received bit)
+def calc_energy_per_bit(NODE_INFO, TRACE):
+    total_energy = calc_energy_consumption(NODE_INFO)
+    return total_energy / (calc_recv_packets(TRACE) * PACKET_SIZE * 8)
+
+
+# Calculate total number of collisionis from all nodes
+def calc_total_collisions(NODE_INFO):
+    collision_count = 0
+    for node in NODE_INFO:
+        collision_count += NODE_INFO[node]["COLLISION_COUNT"]
+
+    return collision_count
+
+
+# Throughput calculation
+def calc_throughput(TRACE):
+    n_recv_packets = calc_recv_packets(TRACE)
+    throughput = (n_recv_packets * 8 * TRACE["PAYLOAD_SIZE"][0]) / ((TRACE["TS"][-1] / 1000000000.0))
+    return throughput
+
+
+# PDR
+def calc_pdr(TRACE):
+    n_recv_packets = calc_recv_packets(TRACE)
+    n_sent_packets = calc_sent_packets(TRACE)
+    pdr = (float(n_recv_packets) / n_sent_packets)
+    return pdr
+
+
+def main():
+    # Parse the trace file to a list of tx/rx events
+    TRACE_FILE_PATH = sys.argv[1]
+    EVENTS = parse_events(TRACE_FILE_PATH)
+    # print_events()
+    TRACE, NODE_INFO = parse_fields(EVENTS)
+    # print_trace()
+
+    # Calculate number of sent and recevied packets
+    n_recv_packets = calc_recv_packets(TRACE)
+    print ("Number of received packets: ", n_recv_packets)
+    n_sent_packets = calc_sent_packets(TRACE)
+    print ("Number of sent packets: ", n_sent_packets)
+    print ("Total number of tx calls: ", calc_tx_calls(TRACE))
+    print ("Total number of rx calls: ", calc_rx_calls(TRACE))
+    print ("Total energy consumption: ", calc_energy_consumption(NODE_INFO))
+    print ("Energy per bit: ", calc_energy_per_bit(NODE_INFO, TRACE))
+    print ("Throughput: ", calc_throughput(TRACE))
+    # print "Throughput per node: ", (n_recv_packets * 8 * TRACE["PAYLOAD_SIZE"][0]) / ((max(TRACE["NODE_ID"]) + 1) * (TRACE["TS"][-1] / 1000000000.0))
+    print ("PDR: ", float(n_recv_packets) / n_sent_packets)
+    print ("Number of collisions: ", calc_total_collisions(NODE_INFO))
+    print ("Instantaneous throuhgput: ", calc_isntantaneous_throughput(TRACE))
+    print ("Average hop count: ", calc_hop_count(TRACE))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/trace_parser_sfama.py
+++ b/scripts/trace_parser_sfama.py
@@ -1,0 +1,331 @@
+#!/usr/bin/python
+"""
+Parse SFAMA ascii trace file from NS-3 Aqua-Sim to extract results from simulation.
+"""
+
+
+import sys
+import numpy
+
+
+# Energy-related pararmeters
+TX_POWER = 60.0     # Watts
+RX_POWER = 0.158     # Watts
+IDLE_POWER = 0.158   # Watts
+LINK_SPEED = 10000.0  # bps
+PACKET_SIZE = 800 + 512 # bytes // 512 bytes is the header size (see the trace files)
+
+
+# Parse trace file to tx/rx events
+def parse_events(trace_file_path):
+    # Store raw tx/rx events, parsed from the original trace file
+    EVENTS = []
+
+    with open(trace_file_path, "r") as f:
+        # Store tx/rx event list
+        event = ""
+        i = 0
+        for line in f:
+
+            if (line[0] == "t" or line[0] =="r") and (i != 0):
+
+                EVENTS.append(event)
+
+                event = line[:-1]
+
+            else:
+                event += line[:-1]
+
+            i += 1
+
+        EVENTS.append(event)
+    return EVENTS
+
+
+def print_events(EVENTS):
+    for event in EVENTS:
+        print (event)
+        print ("")
+
+
+def parse_fields(EVENTS):
+    # TRACE object with parsed fields
+    TRACE = {"RX/TX-MODE": [], "TS": [], "NODE_ID": [], "TX_POWER": [], "RX_POWER": [], "TX_TIME": [], "DIRECTION": [],
+    "NUM_FORWARDS": [], "ERROR": [], "UNIQUE_ID": [], "PTYPE": [], "PAYLOAD_SIZE": [], "MAC_SRC_ADDR": [], "MAC_DST_ADDR": []}
+
+    # Store per Node information: number of processed RX events, number of collisions
+    NODE_VALUES = {"PROCESSED_RX_COUNT": 0, "RX_ENERGY": 0.0, "TX_ENERGY": 0.0, "IDLE_ENERGY": 0.0, "COLLISION_COUNT": 0, "LAST_TS": 0.0}
+    #NODE_INFO = {"NODE_ID": {"PROCESSED_RX_COUNT": 0, "RX_ENERGY": 0.0, "TX_ENERGY": 0.0, "IDLE_ENERGY": 0.0, "COLLISION_COUNT": 0, "LAST_TS": 0.0}}
+    NODE_INFO = {}
+    for i in range(300):
+        NODE_INFO[i] = dict(NODE_VALUES)
+
+    # Parse the fields
+    for line in EVENTS:
+
+        stripped_line = line.split(" ")
+        if line[0] == "t":
+            ptype = stripped_line[37].split("=")[1][:-1]
+            TRACE["PTYPE"].append(ptype)
+            TRACE["RX/TX-MODE"].append("TX")
+            ts = float(stripped_line[1])
+            TRACE["TS"].append(ts)
+            node_id = int(stripped_line[2].split("/")[2])
+            TRACE["NODE_ID"].append(node_id)
+
+            TRACE["TX_POWER"].append(TX_POWER)
+            header_size = int(stripped_line[17].split("=")[1])
+            TRACE["PAYLOAD_SIZE"].append(header_size)
+
+            TRACE["RX_POWER"].append(0)
+            TRACE["TX_TIME"].append(float(stripped_line[16].split("=")[1][1:-2]))
+            
+            TRACE["DIRECTION"].append(stripped_line[18].split("=")[1])
+            TRACE["NUM_FORWARDS"].append(int(stripped_line[19].split("=")[1]))
+            TRACE["ERROR"].append(stripped_line[20].split("=")[1])
+            TRACE["UNIQUE_ID"].append(int(stripped_line[21].split("=")[1]))
+
+            TRACE["MAC_SRC_ADDR"].append(stripped_line[23].split("=")[1])
+            TRACE["MAC_DST_ADDR"].append(stripped_line[24].split("=")[1])
+
+            # Update node info
+            # We need to add the IDLE power to TX power (node can't consume less than IDLE energy when in TX)
+            NODE_INFO[node_id]["TX_ENERGY"] += ((header_size * 8) / LINK_SPEED) * TX_POWER
+            NODE_INFO[node_id]["TX_ENERGY"] += ((header_size * 8) / LINK_SPEED) * IDLE_POWER
+            if ts >= NODE_INFO[node_id]["LAST_TS"]:
+                NODE_INFO[node_id]["IDLE_ENERGY"] += ((ts - NODE_INFO[node_id]["LAST_TS"]) / 1000000000.0) * IDLE_POWER
+                NODE_INFO[node_id]["LAST_TS"] = ts + ((header_size * 8) / LINK_SPEED) * 1000000000.0
+                # print header_size
+            else:
+                NODE_INFO[node_id]["COLLISION_COUNT"] += 1
+                # print "TX", node_id, header_size, ts, "<--->", NODE_INFO[node_id]["LAST_TS"]
+
+
+        elif line[0] == "r":
+            ptype = stripped_line[29].split("=")[1][:-1]
+            TRACE["PTYPE"].append(ptype)
+            TRACE["RX/TX-MODE"].append("RX")
+            ts = float(stripped_line[1])
+            TRACE["TS"].append(ts)
+            node_id = int(stripped_line[2].split("/")[2])
+            TRACE["NODE_ID"].append(node_id)
+
+            TRACE["TX_POWER"].append(TX_POWER)
+
+            header_size = int(stripped_line[9].split("=")[1])
+            TRACE["PAYLOAD_SIZE"].append(header_size)
+
+            TRACE["RX_POWER"].append(0)
+            TRACE["TX_TIME"].append(0)
+            
+            TRACE["DIRECTION"].append(stripped_line[10].split("=")[1])
+            TRACE["NUM_FORWARDS"].append(int(stripped_line[11].split("=")[1]))
+            TRACE["ERROR"].append(stripped_line[12].split("=")[1])
+            TRACE["UNIQUE_ID"].append(int(stripped_line[13].split("=")[1]))
+
+            TRACE["MAC_SRC_ADDR"].append(stripped_line[15].split("=")[1])
+            TRACE["MAC_DST_ADDR"].append(stripped_line[16].split("=")[1])
+
+            # Update node info
+            # if (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0) > NODE_INFO[node_id]["LAST_TS"]:
+            if (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0) >= NODE_INFO[node_id]["LAST_TS"]:
+                NODE_INFO[node_id]["PROCESSED_RX_COUNT"] += 1
+                NODE_INFO[node_id]["IDLE_ENERGY"] += ((ts - NODE_INFO[node_id]["LAST_TS"]) / 1000000000.0) * IDLE_POWER
+                # print header_size
+                # NODE_INFO[node_id]["LAST_TS"] = ts + ((header_size * 8) / LINK_SPEED) * 1000000000.0
+                # NODE_INFO[node_id]["LAST_TS"] = ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0    # Rx event is traced at the end of reception, therefore, we need to find the beginning of Rx
+                NODE_INFO[node_id]["LAST_TS"] = ts
+                NODE_INFO[node_id]["RX_ENERGY"] += ((header_size * 8) / LINK_SPEED) * RX_POWER
+            else:
+                NODE_INFO[node_id]["COLLISION_COUNT"] += 1
+                # print "RX", node_id, header_size, (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0), "<--->", NODE_INFO[node_id]["LAST_TS"]
+                # print (NODE_INFO[node_id]["LAST_TS"] - (ts - (((header_size) * 8) / LINK_SPEED) * 1000000000.0)) / 1000000000.
+
+    return TRACE, NODE_INFO
+
+
+# Print the parsed trace object
+def print_trace(TRACE):
+    for field in TRACE:
+        print ("%s :" % field, TRACE[field])
+        print (len(TRACE[field]))
+        print ("")
+
+
+# Calculate number of packets, received by MAC layer AND sent up to the upper layers
+def calc_recv_packets(TRACE):
+    num_recv_packets = 0
+    processed_ids = []
+
+    # Go through the dictionary and find the packets, which MAC_DST_ADDR matches the address of the node.
+    # Also, ignore duplicate receptions (if any) by checking UNIQUE_ID field
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids and TRACE["PTYPE"][i] == "SFAMA_DATA"):
+            num_recv_packets += 1
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+
+    return num_recv_packets
+
+
+# Calculate number of actual hops a received packet has traversed (avg hop count)
+def calc_hop_count(TRACE):
+    return 1.0
+
+
+# Calculate average end-to-end delay
+def calc_delay(TRACE):
+    delays = []
+    processed_ids = []
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids and TRACE["PTYPE"][i] == "SFAMA_DATA"):
+            # Find the timestamp when this packet were initially sent
+            for j in range(len(TRACE["TS"])):
+                if (TRACE["UNIQUE_ID"][i] == TRACE["UNIQUE_ID"][j] and TRACE["RX/TX-MODE"][j] == "TX"):
+
+                    delays.append((TRACE["TS"][i] - TRACE["TS"][j]) / 1000000000.) # to Seconds
+
+
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+
+    return numpy.array(delays).mean()
+
+
+# Calculate "instantaneous" throuhgput - number of bits received over a second
+def calc_isntantaneous_throughput(TRACE):
+    processed_ids = []
+    # Find the fisrt starting ts
+    start_ts = 0.0
+    num_recv_packets = 0
+    timestamps = []
+    throughputs = []
+    moving_average = []
+    previous_average = 0.0
+    k = 1
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids and TRACE["PTYPE"][i] == "SFAMA_DATA"):
+            start_ts = float(TRACE["TS"][i])
+            num_recv_packets += 1
+            break
+
+    # Go through the dictionary and find the packets, which MAC_DST_ADDR matches the address of the node.
+    # Also, ignore duplicate receptions (if any) by checking UNIQUE_ID field
+    for i in range(1, len(TRACE["TS"])):
+        if (int(TRACE["MAC_DST_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids and TRACE["PTYPE"][i] == "SFAMA_DATA"):
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+            if (float(TRACE["TS"][i] - start_ts)) < 10000000000.0: # if the time difference between current ts and starting ts is less than 10 seconds
+                num_recv_packets += 1
+            
+            else:
+                timestamps.append(float(TRACE["TS"][i] / 1000000000.0))
+                current_throughput = (num_recv_packets * PACKET_SIZE * 8) / ((float(TRACE["TS"][i]) - start_ts) / 1000000000.0)
+                throughputs.append(current_throughput)
+                current_average = previous_average + (current_throughput - previous_average) / k
+                moving_average.append(current_average)
+                previous_average = current_average
+                k += 1
+                # inst_throuhgput[float(TRACE["TS"][i] / 1000000000.0)] = (num_recv_packets * PACKET_SIZE * 8) / ((float(TRACE["TS"][i]) - start_ts) / 1000000000.0) # bits
+                start_ts = float(TRACE["TS"][i])
+                num_recv_packets = 1
+
+    return (timestamps, throughputs, moving_average)
+
+
+# Calculate number of packets, sent by the source node (not counting the relays)
+def calc_sent_packets(TRACE):
+    num_sent_packets = 0
+    processed_ids = []
+
+    # Go through the dictionary and find the packets, which MAC_SRC_ADDR mathes the address of the node.
+    # Also, ignore duplicate receptions (if any) by checking UNIQUE_ID field
+    for i in range(len(TRACE["TS"])):
+        if (int(TRACE["MAC_SRC_ADDR"][i]) == TRACE["NODE_ID"][i] + 1) and (TRACE["UNIQUE_ID"][i] not in processed_ids and TRACE["PTYPE"][i] == "SFAMA_DATA"):
+            num_sent_packets += 1
+            processed_ids.append(TRACE["UNIQUE_ID"][i])
+
+    return num_sent_packets
+
+
+# Calculate total number of TX events
+def calc_tx_calls(TRACE):
+    return TRACE["RX/TX-MODE"].count("TX")
+
+
+# Calculate total number of RX events
+def calc_rx_calls(TRACE):
+    return TRACE["RX/TX-MODE"].count("RX")
+
+
+# Calculate total energy consumption
+def calc_energy_consumption(NODE_INFO):
+    total_energy = 0.0
+
+    # print NODE_INFO
+    for node in NODE_INFO:
+        total_energy += NODE_INFO[node]["RX_ENERGY"]
+    	# print "RX_ENERGY: ", NODE_INFO[node]["RX_ENERGY"]
+        total_energy += NODE_INFO[node]["TX_ENERGY"]
+        # print "TX_ENERGY: ", NODE_INFO[node]["TX_ENERGY"]
+        total_energy += NODE_INFO[node]["IDLE_ENERGY"]
+        # print "IDLE_ENERGY: ", NODE_INFO[node]["IDLE_ENERGY"]
+
+    # print total_energy
+    return total_energy
+
+
+# Calculate energy per bit (received bit)
+def calc_energy_per_bit(NODE_INFO, TRACE):
+    total_energy = calc_energy_consumption(NODE_INFO)
+    return total_energy / (calc_recv_packets(TRACE) * PACKET_SIZE * 8)
+
+
+# Calculate total number of collisionis from all nodes
+def calc_total_collisions(NODE_INFO):
+    collision_count = 0
+    for node in NODE_INFO:
+        collision_count += NODE_INFO[node]["COLLISION_COUNT"]
+
+    return collision_count
+
+
+# Throughput calculation
+def calc_throughput(TRACE):
+    n_recv_packets = calc_recv_packets(TRACE)
+    throughput = (n_recv_packets * 8 * PACKET_SIZE) / ((TRACE["TS"][-1] / 1000000000.0))
+    return throughput
+
+
+# PDR
+def calc_pdr(TRACE):
+    n_recv_packets = calc_recv_packets(TRACE)
+    n_sent_packets = calc_sent_packets(TRACE)
+    pdr = (float(n_recv_packets) / n_sent_packets)
+    return pdr
+
+
+def main():
+    # Parse the trace file to a list of tx/rx events
+    TRACE_FILE_PATH = sys.argv[1]
+    EVENTS = parse_events(TRACE_FILE_PATH)
+    # print_events()
+    TRACE, NODE_INFO = parse_fields(EVENTS)
+    # print_trace()
+
+    # Calculate number of sent and recevied packets
+    n_recv_packets = calc_recv_packets(TRACE)
+    print ("Number of received packets: ", n_recv_packets)
+    n_sent_packets = calc_sent_packets(TRACE)
+    print ("Number of sent packets: ", n_sent_packets)
+    print ("Total number of tx calls: ", calc_tx_calls(TRACE))
+    print ("Total number of rx calls: ", calc_rx_calls(TRACE))
+    print ("Total energy consumption: ", calc_energy_consumption(NODE_INFO))
+    print ("Energy per bit: ", calc_energy_per_bit(NODE_INFO, TRACE))
+    print ("Throughput: ", calc_throughput(TRACE))
+    # print "Throughput per node: ", (n_recv_packets * 8 * TRACE["PAYLOAD_SIZE"][0]) / ((max(TRACE["NODE_ID"]) + 1) * (TRACE["TS"][-1] / 1000000000.0))
+    print ("PDR: ", float(n_recv_packets) / n_sent_packets)
+    print ("Number of collisions: ", calc_total_collisions(NODE_INFO))
+    print ("Instantaneous throuhgput: ", calc_isntantaneous_throughput(TRACE))
+    print ("Average hop count: ", calc_hop_count(TRACE))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Major update, adding support for new LIBRA-MAC protocol, with various fixes to SFAMA, PHY-layer and trace-file model.

new:
- added new LIBRA-MAC protocol `aqua-sim-mac-libra`
- new traffic generation model `aqua-sim-application` with random destinations, based on `OnOffApplication`
- new simulation scripts to compare `LIBRA`, `ALOHA`, and `SFAMA` together: `libra_grid_test.cc`, `aloha_grid_test.cc`, and `sfama_grid_test.cc`
- new `scripts/` folder that contains Python-scripts to parse raw trace-file data after simulations for further analysis

modified/fixed:
- fixed SFAMA stability issues
- modified `aqua-sim-phy-cmn` PHY layer to support new LIBRA protocol, and detect/trace hidden Rx-Rx collisions
- updated `README` with description how to run & compare LIBRA, ALOHA, and SFAMA together
