### PR TITLE
Added iomanip; fails without this

### DIFF
--- a/examples/aloha_grid_test.cc
+++ b/examples/aloha_grid_test.cc
@@ -17,6 +17,7 @@
 
 #include <random>
 #include <math.h>
+#include <iomanip>
 
 /*
  * ALOHA NxN grid random destination topology tests

--- a/examples/sfama_grid_test.cc
+++ b/examples/sfama_grid_test.cc
@@ -17,6 +17,7 @@
 
 #include <random>
 #include <math.h>
+#include <iomanip>
 
 /*
  * SFAMA NxN grid random destination topology tests


### PR DESCRIPTION
When trying to build `ns3` with `aqua-sim-ng`, it failed on this error for both `aloha_grid_test.cc` and `sfama_grid_test.cc`:

```
/.../ns-3-dev/src/aqua-sim-ng/examples/aloha_grid_test.cc:172:32: error: ‘setprecision’ is not a member of ‘std’
  172 |   stream << std::fixed << std::setprecision(2) << lambda;
      |                                ^~~~~~~~~~~~
/.../ns-3-dev/src/aqua-sim-ng/examples/aloha_grid_test.cc:20:1: note: ‘std::setprecision’ is defined in header ‘<iomanip>’; did you forget to ‘#include <iomanip>’?
   19 | #include <math.h>
  +++ |+#include <iomanip>
   20 | 
   ```
   
   I am simply adding these `#include` lines in these files.